### PR TITLE
fix: .cjs and destructure of undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 0.3.0 (2021-02-07)
+
+- fix: cjs output from sveltekit requires rename of local require in handler.js
+- fix: destructure of undefined in index.js.adapter(). Fixes #5
+
 ## 0.2.0 (2021-01-06)
 
 - chore: build with microbundle instead of Rollup directly

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   ],
   "source": "src/index.js",
   "main": "dist/index.js",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "dependencies": {
     "@sveltejs/app-utils": "1.0.0-next.0",
     "joi": "^17.3.0"

--- a/src/files/handler.js
+++ b/src/files/handler.js
@@ -1,5 +1,5 @@
 const {get_body: getBody} = require('@sveltejs/app-utils/http');
-const app = require('./app.js');
+const app = require('./app.cjs');
 
 exports.sveltekitServer = async (request, response) => {
 	const {pathname, query = ''} = new URL(

--- a/src/index.js
+++ b/src/index.js
@@ -128,7 +128,7 @@ async function adapter(
 	builder,
 	parameters
 ) {
-	const 	{
+	const {
 		hostingSite = null,
 		sourceRewriteMatch = '**',
 		firebaseJson = 'firebase.json',

--- a/src/index.js
+++ b/src/index.js
@@ -126,13 +126,14 @@ function getFile(filepath) {
 
 async function adapter(
 	builder,
-	{
-		hostingSite,
+	parameters
+) {
+	const 	{
+		hostingSite = null,
 		sourceRewriteMatch = '**',
 		firebaseJson = 'firebase.json',
-		cloudRunBuildDir
-	}
-) {
+		cloudRunBuildDir = null
+	} = parameters;
 	// Joi.array.single converts the hosting field to an array if a single item is provided
 	const firebaseConfig = validateFirebaseConfig(
 		firebaseJson,


### PR DESCRIPTION
# Summary

<!-- Provide a general description of the code changes in your pull request. -->

SvelteKit `1.0.0-next.31` outputs `.cjs` so update the `require` of `handler.js`

Fix bug where destructure in `index.js.adpater()` failed due to missing default

Fixes: #5, #6
