### PR TITLE
fix: destructure of adapter config error

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,11 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npm run fix
+FILES=$(git diff --cached --name-only --diff-filter=ACMR "*.js" "*.jsx" | sed 's| |\\ |g')
+[ -z "$FILES" ] && exit 0
+
+# Fix all selected files
+echo "$FILES" | xargs ./node_modules/.bin/xo --fix
+
+# Add back the modified files to staging
+echo "$FILES" | xargs git add

--- a/src/index.js
+++ b/src/index.js
@@ -129,13 +129,12 @@ function getFile(filepath) {
 	}
 }
 
-async function adapter(builder, parameters) {
-	const {
-		hostingSite = null,
-		sourceRewriteMatch = '**',
-		firebaseJson = 'firebase.json',
-		cloudRunBuildDir = null
-	} = parameters;
+async function adapter(builder, {
+	hostingSite = null,
+	sourceRewriteMatch = '**',
+	firebaseJson = 'firebase.json',
+	cloudRunBuildDir = null
+} = {}) {
 	// Joi.array.single converts the hosting field to an array if a single item is provided
 	const firebaseConfig = validateFirebaseConfig(
 		firebaseJson,


### PR DESCRIPTION
# Summary

<!-- Provide a general description of the code changes in your pull request. -->

Investigating #6 uncovered two errors:

1. adapter logging was no longer advising the user how to setup their server
2. adapter configuration did not support an empty config as the object param did not have a default set so tried to destructure `undefined`

Fixes were included:

1. in #9 
2. is being fixed here

Fixes: #6 

## Other Information

This PR also fixes an issue with the `pre-commit` hook introduced in #10 It now adds to formatted code to the current commit.