### PR TITLE
fix: inline svelte-app-utils lib

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2139,9 +2139,9 @@
       }
     },
     "@sideway/address": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.0.tgz",
-      "integrity": "sha512-wAH/JYRXeIFQRsxerIuLjgUu2Xszam+O5xKeatJ4oudShOOirfmsQ1D6LL54XOU2tizpCYku+s1wmU0SYdpoSA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.1.tgz",
+      "integrity": "sha512-+I5aaQr3m0OAmMr7RQ3fR9zx55sejEYR2BFJaxL+zT3VM2611X0SHvPWIbAUBZVTn/YzYKbV8gJ2oT/QELknfQ==",
       "requires": {
         "@hapi/hoek": "^9.0.0"
       }
@@ -2163,11 +2163,18 @@
       "dev": true
     },
     "@sveltejs/app-utils": {
-      "version": "1.0.0-next.0",
-      "resolved": "https://registry.npmjs.org/@sveltejs/app-utils/-/app-utils-1.0.0-next.0.tgz",
-      "integrity": "sha512-4fCuD+aLrq/iFVJWosIv8oi43tv4o7bGZVyNHMBamdIaVTcydRaPjxQCTM8OQPRVftHyrTIIvT3uH03kAxHZ0Q==",
+      "version": "1.0.0-next.1",
+      "resolved": "https://registry.npmjs.org/@sveltejs/app-utils/-/app-utils-1.0.0-next.1.tgz",
+      "integrity": "sha512-H0VqLr3NYNiomIXI5k2YLW20fAXy3CXz8jiG8zpEmySZ9LV/90RGlmB7phEbS1NU/1S5qhxNNbVH7smWt7XeuQ==",
       "requires": {
-        "mime": "^2.4.6"
+        "mime": "^2.5.0"
+      },
+      "dependencies": {
+        "mime": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz",
+          "integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg=="
+        }
       }
     },
     "@szmarczak/http-timer": {
@@ -7410,9 +7417,9 @@
       }
     },
     "joi": {
-      "version": "17.3.0",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.3.0.tgz",
-      "integrity": "sha512-Qh5gdU6niuYbUIUV5ejbsMiiFmBdw8Kcp8Buj2JntszCkCfxJ9Cz76OtHxOZMPXrt5810iDIXs+n1nNVoquHgg==",
+      "version": "17.4.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.4.0.tgz",
+      "integrity": "sha512-F4WiW2xaV6wc1jxete70Rw4V/VuMd6IN+a5ilZsxG4uYtUXWu2kq9W5P2dz30e7Gmw8RCbY/u/uk+dMPma9tAg==",
       "requires": {
         "@hapi/hoek": "^9.0.0",
         "@hapi/topo": "^5.0.0",
@@ -8132,7 +8139,8 @@
     "mime": {
       "version": "2.4.7",
       "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.7.tgz",
-      "integrity": "sha512-dhNd1uA2u397uQk3Nv5LM4lm93WYDUXFn3Fu291FJerns4jyTudqhIWe4W04YLy7Uk1tm1Ore04NpjRvQp/NPA=="
+      "integrity": "sha512-dhNd1uA2u397uQk3Nv5LM4lm93WYDUXFn3Fu291FJerns4jyTudqhIWe4W04YLy7Uk1tm1Ore04NpjRvQp/NPA==",
+      "dev": true
     },
     "mimic-fn": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
   "main": "dist/index.js",
   "version": "0.3.2",
   "dependencies": {
-    "@sveltejs/app-utils": "1.0.0-next.0",
-    "joi": "^17.3.0"
+    "@sveltejs/app-utils": "^1.0.0-next.1",
+    "joi": "^17.4.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^11.0.0",
@@ -37,6 +37,7 @@
     "husky": "^5.0.8",
     "microbundle": "^0.13.0",
     "rewire": "^5.0.0",
+    "rimraf": "^3.0.2",
     "semantic-release": "^17.4.0",
     "xo": "^0.37.1"
   },
@@ -48,7 +49,11 @@
     "fix": "xo --fix",
     "test": "xo && ava",
     "dev": "microbundle watch --target node",
-    "build": "microbundle --target node && mkdir -p dist/files && cp -p src/files/cloud_run_package.json dist/files/package.json && cp -p src/files/handler.js dist/files/handler.js"
+    "prebuild": "rimraf dist",
+    "build:cli": "microbundle --target node --external none",
+    "build:handler": "microbundle --target node --format es,cjs --external none --entry src/files/handler.js --output dist/files/handler.js",
+    "build:cloudrun": "mkdir -p dist/files && cp -p src/files/cloud_run_package.json dist/files/package.json",
+    "build": "npm run build:cli && npm run build:handler && npm run build:cloudrun"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/src/files/handler.js
+++ b/src/files/handler.js
@@ -1,9 +1,9 @@
-// deps - inlined
-import {get_body as getBody} from '@sveltejs/app-utils/http'
+// Deps - inlined
+import {get_body as getBody} from '@sveltejs/app-utils/http';
 
 const app = require('./app.js');
 
-export default async (request, response) => {
+const svelteKit = async (request, response) => {
 	const {pathname, query = ''} = new URL(
 		request.url || '',
 		`https://${request.headers.host}/`
@@ -25,3 +25,5 @@ export default async (request, response) => {
 
 	return response.writeHead(404).end();
 };
+
+export default svelteKit;

--- a/src/files/handler.js
+++ b/src/files/handler.js
@@ -1,7 +1,9 @@
-const {get_body: getBody} = require('@sveltejs/app-utils/http');
-const app = require('./app.cjs');
+// deps - inlined
+import {get_body as getBody} from '@sveltejs/app-utils/http'
 
-exports.sveltekitServer = async (request, response) => {
+const app = require('./app.js');
+
+export default async (request, response) => {
 	const {pathname, query = ''} = new URL(
 		request.url || '',
 		`https://${request.headers.host}/`

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,10 @@
-const {existsSync, readFileSync} = require('fs');
+// deps - installed
+const fs = require('fs');
 const path = require('path');
-const {copy} = require('@sveltejs/app-utils/files');
 const Joi = require('joi');
+
+// deps - inlined
+import {copy} from '@sveltejs/app-utils/files';
 
 // If valid config returns the config as JS Object, else throws error
 function validateFirebaseConfig(firebaseJson, hostingSite, sourceRewriteMatch) {
@@ -118,9 +121,9 @@ for either a Function or Cloud Run service.
 }
 
 function getFile(filepath) {
-	if (existsSync(filepath)) {
+	if (fs.existsSync(filepath)) {
 		try {
-			return readFileSync(filepath, 'utf-8');
+			return fs.readFileSync(filepath, 'utf-8');
 		} catch (error) {
 			throw new Error(`Error reading ${filepath}: ${error.message}`);
 		}
@@ -194,7 +197,7 @@ async function adapter(builder, {
 				.replace(/\W/g, '')
 				.concat('Server');
 			if (
-				existsSync(functionsIndexPath) &&
+				fs.existsSync(functionsIndexPath) &&
 				!getFile(functionsIndexPath).includes(`${cloudFunctionName} =`)
 			) {
 				builder.log.warn(

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,9 @@
-// deps - installed
+// Deps - installed
 const fs = require('fs');
 const path = require('path');
 const Joi = require('joi');
 
-// deps - inlined
+// Deps - inlined
 import {copy} from '@sveltejs/app-utils/files';
 
 // If valid config returns the config as JS Object, else throws error


### PR DESCRIPTION
# Summary

<!-- Provide a general description of the code changes in your pull request. -->

Inline the lib `@sveltejs/app-utils` into the `handler.js` and adapter entrypoint.

Fixes: #12

## Other Information

<!-- If there is anything else that is relevant to your pull request include that information here. -->

<!--Thank you for contributing to svelte-adapter-firebase! -->

Despite this fixing the reported issue, the change to ESM and no CJS export from `@sveltejs/kit` means the error of ESM in a Cloud Function will show up in the when the `handler.js` executes it's require of `app.js` which itself `imports` ESM