### PR TITLE
chore: improve test reliability

### DIFF
--- a/tests/index.test.mjs
+++ b/tests/index.test.mjs
@@ -1,11 +1,15 @@
 import test from 'ava';
+import path from 'path';
+import {fileURLToPath} from 'url';
 import {parseFirebaseConfiguration, validCloudRunServiceId} from '../src/utils.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // ParseFirebaseConfiguration: Valid configs
 test(
 	'Firebase config w Cloud Functions & single site',
 	t => {
-		const config = {hostingSite: undefined, sourceRewriteMatch: '**', firebaseJson: './tests/fixtures/successes/cf_site.json'};
+		const config = {hostingSite: undefined, sourceRewriteMatch: '**', firebaseJson: path.join(__dirname, 'fixtures/successes/cf_site.json')};
 		const result = parseFirebaseConfiguration(config);
 		const expectedResult = {functions: {name: 'some_func', source: 'functions'}, cloudRun: false, publicDir: 'app'};
 
@@ -16,7 +20,7 @@ test(
 test(
 	'Firebase config w Cloud Functions & multiple sites',
 	t => {
-		const config = {hostingSite: 'app', sourceRewriteMatch: '**', firebaseJson: './tests/fixtures/successes/cf_sites.json'};
+		const config = {hostingSite: 'app', sourceRewriteMatch: '**', firebaseJson: path.join(__dirname, 'fixtures/successes/cf_sites.json')};
 		const result = parseFirebaseConfiguration(config);
 		const expectedResult = {functions: {name: 'some_func', source: 'functions'}, cloudRun: false, publicDir: 'app'};
 
@@ -27,7 +31,7 @@ test(
 test(
 	'Firebase config w Cloud Run & single site',
 	t => {
-		const config = {hostingSite: undefined, sourceRewriteMatch: '**', firebaseJson: './tests/fixtures/successes/cr_site.json'};
+		const config = {hostingSite: undefined, sourceRewriteMatch: '**', firebaseJson: path.join(__dirname, 'fixtures/successes/cr_site.json')};
 		const result = parseFirebaseConfiguration(config);
 		const expectedResult = {functions: false, cloudRun: {serviceId: 'some-service', region: 'us-central1'}, publicDir: 'app'};
 
@@ -38,7 +42,7 @@ test(
 test(
 	'Firebase config w Cloud Run & multiple sites',
 	t => {
-		const config = {hostingSite: 'app', sourceRewriteMatch: '**', firebaseJson: './tests/fixtures/successes/cr_sites.json'};
+		const config = {hostingSite: 'app', sourceRewriteMatch: '**', firebaseJson: path.join(__dirname, 'fixtures/successes/cr_sites.json')};
 		const result = parseFirebaseConfiguration(config);
 		const expectedResult = {functions: false, cloudRun: {serviceId: 'some-service', region: 'us-central1'}, publicDir: 'app'};
 
@@ -50,108 +54,108 @@ test(
 test(
 	'Firebase config does not exist',
 	t => {
-		const config = {hostingSite: undefined, sourceRewriteMatch: '**', firebaseJson: './does_not_exist.json'};
+		const config = {hostingSite: undefined, sourceRewriteMatch: '**', firebaseJson: path.join('./does_not_exist.json')};
 		const error = t.throws(() => parseFirebaseConfiguration(config));
-		t.is(error.message, 'File ./does_not_exist.json does not exist. The provided file should exist and be a Firebase JSON config.');
+		t.is(error.message, 'File does_not_exist.json does not exist. The provided file should exist and be a Firebase JSON config.');
 	}
 );
 
 test(
 	'Firebase config is invalid json',
 	t => {
-		const config = {hostingSite: undefined, sourceRewriteMatch: '**', firebaseJson: './tests/fixtures/failures/invalid.json'};
+		const config = {hostingSite: undefined, sourceRewriteMatch: '**', firebaseJson: path.join(__dirname, 'fixtures/failures/invalid.json')};
 		const error = t.throws(() => parseFirebaseConfiguration(config));
-		t.is(error.message, 'Error parsing ./tests/fixtures/failures/invalid.json. Unexpected token } in JSON at position 28');
+		t.is(error.message, `Error parsing ${__dirname}/fixtures/failures/invalid.json. Unexpected token } in JSON at position 28`);
 	}
 );
 
 test(
 	'Firebase config without "hosting" field',
 	t => {
-		const config = {hostingSite: undefined, sourceRewriteMatch: '**', firebaseJson: './tests/fixtures/failures/missing_hosting.json'};
+		const config = {hostingSite: undefined, sourceRewriteMatch: '**', firebaseJson: path.join(__dirname, 'fixtures/failures/missing_hosting.json')};
 		const error = t.throws(() => parseFirebaseConfiguration(config));
-		t.is(error.message, 'Error with config ./tests/fixtures/failures/missing_hosting.json. "hosting" field required.');
+		t.is(error.message, `Error with config ${__dirname}/fixtures/failures/missing_hosting.json. "hosting" field required.`);
 	}
 );
 
 test(
 	'Firebase config w multiple sites missing "site" identifier',
 	t => {
-		const config = {hostingSite: undefined, sourceRewriteMatch: '**', firebaseJson: './tests/fixtures/failures/sites_missing_rewrites.json'};
+		const config = {hostingSite: undefined, sourceRewriteMatch: '**', firebaseJson: path.join(__dirname, 'fixtures/failures/sites_missing_rewrites.json')};
 		const error = t.throws(() => parseFirebaseConfiguration(config));
-		t.is(error.message, 'Error with config ./tests/fixtures/failures/sites_missing_rewrites.json. "hosting" configs should identify their "site" name as Firebase supports multiple sites. This site config does not {"public":"some_dir"}');
+		t.is(error.message, `Error with config ${__dirname}/fixtures/failures/sites_missing_rewrites.json. "hosting" configs should identify their "site" name as Firebase supports multiple sites. This site config does not {"public":"some_dir"}`);
 	}
 );
 
 test(
 	'Firebase config multiple sites require a hostingSite to be specified',
 	t => {
-		const config = {hostingSite: undefined, sourceRewriteMatch: '**', firebaseJson: './tests/fixtures/failures/cf_multi_site_requires_hostingSite.json'};
+		const config = {hostingSite: undefined, sourceRewriteMatch: '**', firebaseJson: path.join(__dirname, 'fixtures/failures/cf_multi_site_requires_hostingSite.json')};
 		const error = t.throws(() => parseFirebaseConfiguration(config));
-		t.is(error.message, 'Error with config ./tests/fixtures/failures/cf_multi_site_requires_hostingSite.json. No "hosting[].site" match for undefined. Ensure your svelte.config.js adapter config "hostingSite" matches an item in your Firebase config.');
+		t.is(error.message, `Error with config ${__dirname}/fixtures/failures/cf_multi_site_requires_hostingSite.json. No "hosting[].site" match for undefined. Ensure your svelte.config.js adapter config "hostingSite" matches an item in your Firebase config.`);
 	}
 );
 
 test(
 	'Firebase config w missing "public"',
 	t => {
-		const config = {hostingSite: undefined, sourceRewriteMatch: '**', firebaseJson: './tests/fixtures/failures/site_missing_public.json'};
+		const config = {hostingSite: undefined, sourceRewriteMatch: '**', firebaseJson: path.join(__dirname, 'fixtures/failures/site_missing_public.json')};
 		const error = t.throws(() => parseFirebaseConfiguration(config));
-		t.is(error.message, 'Error with config ./tests/fixtures/failures/site_missing_public.json. "hosting[].public" field is required and should be a string. Hosting config with error: {}');
+		t.is(error.message, `Error with config ${__dirname}/fixtures/failures/site_missing_public.json. "hosting[].public" field is required and should be a string. Hosting config with error: {}`);
 	}
 );
 
 test(
 	'Firebase config w site missing "rewrites"',
 	t => {
-		const config = {hostingSite: undefined, sourceRewriteMatch: '**', firebaseJson: './tests/fixtures/failures/site_missing_rewrite.json'};
+		const config = {hostingSite: undefined, sourceRewriteMatch: '**', firebaseJson: path.join(__dirname, 'fixtures/failures/site_missing_rewrite.json')};
 		const error = t.throws(() => parseFirebaseConfiguration(config));
-		t.is(error.message, 'Error with config ./tests/fixtures/failures/site_missing_rewrite.json. "hosting[].rewrites" field  required in hosting config and should be an array of object(s). Hosting config with error: {"public":"app"}');
+		t.is(error.message, `Error with config ${__dirname}/fixtures/failures/site_missing_rewrite.json. "hosting[].rewrites" field  required in hosting config and should be an array of object(s). Hosting config with error: {"public":"app"}`);
 	}
 );
 
 test(
 	'Firebase config w "rewrites" mismatch',
 	t => {
-		const config = {hostingSite: undefined, sourceRewriteMatch: 'no_match', firebaseJson: './tests/fixtures/failures/cf_site_rewrite_mismatch.json'};
+		const config = {hostingSite: undefined, sourceRewriteMatch: 'no_match', firebaseJson: path.join(__dirname, 'fixtures/failures/cf_site_rewrite_mismatch.json')};
 		const error = t.throws(() => parseFirebaseConfiguration(config));
-		t.is(error.message, 'Error with config ./tests/fixtures/failures/cf_site_rewrite_mismatch.json. "hosting[].rewrites[*]" does not contain a config with "source":"no_match" and either "function" or "run". Is your "sourceRewriteMatch" in svelte.config.js correct?');
+		t.is(error.message, `Error with config ${__dirname}/fixtures/failures/cf_site_rewrite_mismatch.json. "hosting[].rewrites[*]" does not contain a config with "source":"no_match" and either "function" or "run". Is your "sourceRewriteMatch" in svelte.config.js correct?`);
 	}
 );
 
 test(
 	'Firebase config w Cloud Run missing required "serviceId" field',
 	t => {
-		const config = {hostingSite: undefined, sourceRewriteMatch: '**', firebaseJson: './tests/fixtures/failures/cr_missing_serviceId.json'};
+		const config = {hostingSite: undefined, sourceRewriteMatch: '**', firebaseJson: path.join(__dirname, 'fixtures/failures/cr_missing_serviceId.json')};
 		const error = t.throws(() => parseFirebaseConfiguration(config));
-		t.is(error.message, 'Error with config ./tests/fixtures/failures/cr_missing_serviceId.json. Cloud Run rewrite configuration missing required field "serviceId". Rewrite config with error: {"source":"**","run":{}}');
+		t.is(error.message, `Error with config ${__dirname}/fixtures/failures/cr_missing_serviceId.json. Cloud Run rewrite configuration missing required field "serviceId". Rewrite config with error: {"source":"**","run":{}}`);
 	}
 );
 
 test(
 	'Firebase config w Cloud Run incompatible serviceId field',
 	t => {
-		const config = {hostingSite: undefined, sourceRewriteMatch: '**', firebaseJson: './tests/fixtures/failures/cr_invalid_serviceId.json'};
+		const config = {hostingSite: undefined, sourceRewriteMatch: '**', firebaseJson: path.join(__dirname, 'fixtures/failures/cr_invalid_serviceId.json')};
 		const error = t.throws(() => parseFirebaseConfiguration(config));
-		t.is(error.message, 'Error with config ./tests/fixtures/failures/cr_invalid_serviceId.json. "hosting[].public" field is required and should be a string. Hosting config with error: {"rewrites":[{"source":"**","run":{"serviceId":"anInvalidServiceId"}}]}');
+		t.is(error.message, `Error with config ${__dirname}/fixtures/failures/cr_invalid_serviceId.json. "hosting[].public" field is required and should be a string. Hosting config with error: {"rewrites":[{"source":"**","run":{"serviceId":"anInvalidServiceId"}}]}`);
 	}
 );
 
 test(
 	'Firebase config w Cloud Run incompatible region field',
 	t => {
-		const config = {hostingSite: undefined, sourceRewriteMatch: '**', firebaseJson: './tests/fixtures/failures/cr_invalid_region.json'};
+		const config = {hostingSite: undefined, sourceRewriteMatch: '**', firebaseJson: path.join(__dirname, 'fixtures/failures/cr_invalid_region.json')};
 		const error = t.throws(() => parseFirebaseConfiguration(config));
-		t.is(error.message, 'Error with config ./tests/fixtures/failures/cr_invalid_region.json. Firebase Hosting rewrites only support "regions":"us-central1" (docs - https://firebase.google.com/docs/functions/locations#http_and_client-callable_functions). Change "not-a-region" accordingly.');
+		t.is(error.message, `Error with config ${__dirname}/fixtures/failures/cr_invalid_region.json. Firebase Hosting rewrites only support "regions":"us-central1" (docs - https://firebase.google.com/docs/functions/locations#http_and_client-callable_functions). Change "not-a-region" accordingly.`);
 	}
 );
 
 test(
 	'Firebase config w Cloud Functions & single site missing top-level functions',
 	t => {
-		const config = {hostingSite: undefined, sourceRewriteMatch: '**', firebaseJson: './tests/fixtures/failures/cf_site_missing_functions.json'};
+		const config = {hostingSite: undefined, sourceRewriteMatch: '**', firebaseJson: path.join(__dirname, 'fixtures/failures/cf_site_missing_functions.json')};
 		const error = t.throws(() => parseFirebaseConfiguration(config));
-		t.is(error.message, 'Error with config ./tests/fixtures/failures/cf_site_missing_functions.json. If you\'re using Cloud Functions for your SSR rewrite rule, you need to define a "functions.source" field (of type string) at your config root.');
+		t.is(error.message, `Error with config ${__dirname}/fixtures/failures/cf_site_missing_functions.json. If you're using Cloud Functions for your SSR rewrite rule, you need to define a "functions.source" field (of type string) at your config root.`);
 	}
 );
 


### PR DESCRIPTION
# Summary

Improve the test reliability by detecting `__dirname` and using that to reference `tests/fixtures`
