### PR TITLE
feat: cloud function support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 :heavy_check_mark: SSR on [Cloud Run](https://firebase.google.com/docs/hosting/cloud-run) :information_source: recommended</br>
 :heavy_check_mark: [Multiple Hosting Sites](https://firebase.google.com/docs/hosting/multisites#add_additional_sites)</br>
-:x: SSR on [Cloud Functions](https://firebase.google.com/docs/hosting/functions)</br>
+:heavy_check_mark: SSR on [Cloud Functions](https://firebase.google.com/docs/hosting/functions)</br>
 :x: Integrates with existing [JavaScript or TypeScript Cloud Functions](https://firebase.google.com/docs/functions/typescript)!</br>
 :x: Local production testing with [Firebase Emulator](https://firebase.google.com/docs/emulator-suite)</br>
 

--- a/README.md
+++ b/README.md
@@ -566,7 +566,7 @@ pnpm i
 
 ### todo
 
-- fix Cloud Functions deployment
+- create pros/cons comparison of Cloud Functions vs Cloud Run
 - e2e test workflow
   - on merge to `main`
   - wait until `workflows/release.yml` is released
@@ -576,3 +576,7 @@ pnpm i
   - test site availability with Playwright (or something similar)
   - report Lighthouse statistics?
   - site should be the docs for this adapter
+
+#### external
+
+- Cloud Function validation linked in `utils.js` to two different sources indicates that it is being validated by `firebase-tools` in two separate places. PR a fix there.

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@rollup/plugin-node-resolve": "^11.2.0",
     "@semantic-release/changelog": "^5.0.1",
     "@semantic-release/git": "^9.0.0",
+    "@types/node": "^14.14.35",
     "ava": "^3.15.0",
     "husky": "^5.0.8",
     "rimraf": "^3.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ devDependencies:
   '@rollup/plugin-node-resolve': 11.2.0_rollup@2.41.2
   '@semantic-release/changelog': 5.0.1_semantic-release@17.4.2
   '@semantic-release/git': 9.0.0_semantic-release@17.4.2
+  '@types/node': 14.14.35
   ava: 3.15.0
   husky: 5.1.3
   rimraf: 3.0.2
@@ -767,6 +768,10 @@ packages:
     dev: true
     resolution:
       integrity: sha512-dBPaxocOK6UVyvhbnpFIj2W+S+1cBTkHQbFQfeeJhoKFbzYcVUGHvddeWPSucKATb3F0+pgDq0i6ghEaZjsugA==
+  /@types/node/14.14.35:
+    dev: true
+    resolution:
+      integrity: sha512-Lt+wj8NVPx0zUmUwumiVXapmaLUcAk3yPuHCFVXras9k5VT9TdhJqKqGVUQCD60OTMCl0qxJ57OiTL0Mic3Iag==
   /@types/normalize-package-data/2.4.0:
     dev: true
     resolution:
@@ -6833,6 +6838,7 @@ specifiers:
   '@semantic-release/changelog': ^5.0.1
   '@semantic-release/git': ^9.0.0
   '@sveltejs/app-utils': ^1.0.0-next.3
+  '@types/node': ^14.14.35
   ava: ^3.15.0
   husky: ^5.0.8
   rimraf: ^3.0.2

--- a/src/cli.js
+++ b/src/cli.js
@@ -106,7 +106,7 @@ function adaptToCloudRun({builder, serviceId, region, cloudRunBuildDir}) {
 
 	// Prepare Cloud Run package.json - read SvelteKit App 'package.json', modify the JSON, write to serverOutputDir
 	const pkgjson = JSON.parse(readFileSync('package.json', 'utf-8'));
-	pkgjson.scripts.start = 'functions-framework --target=svelteKit';
+	pkgjson.scripts.start = 'functions-framework --target=default';
 	pkgjson.dependencies['@google-cloud/functions-framework'] = '^1.7.1'; // Peer-dep of this adapter instead?
 	pkgjson.engines = {node: '14'};
 	delete pkgjson.type;
@@ -123,7 +123,7 @@ function adaptToCloudRun({builder, serviceId, region, cloudRunBuildDir}) {
 		// eslint-disable-next-line indent
 `To deploy your Cloud Run service, run this command:
 +--------------------------------------------------+
-gcloud beta run deploy ${serviceId} --platform managed --region ${region} --source ${serverOutputDir} --allow-unauthenticated --project <YOUR_PROJECT>
+gcloud beta run deploy ${serviceId} --platform managed --region ${region} --source ${serverOutputDir} --allow-unauthenticated
 +--------------------------------------------------+`
 	);
 }

--- a/src/files/index.cjs
+++ b/src/files/index.cjs
@@ -1,4 +1,4 @@
-exports.svelteKit = async (request, response) => {
+exports.default = async (request, response) => {
 	const {default: app} = await import('./handler.mjs');
 	await app(request, response);
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -79,6 +79,10 @@ export function parseFirebaseConfiguration({hostingSite, sourceRewriteMatch, fir
 		throw new Error(`Error with config ${firebaseJson}. Firebase Hosting rewrites only support "regions":"us-central1" (docs - https://firebase.google.com/docs/functions/locations#http_and_client-callable_functions). Change "${rewriteConfig.run.region}" accordingly.`);
 	}
 
+	if (rewriteConfig?.function && !validCloudFunctionName(rewriteConfig.function)) {
+		throw new Error(`Error with config ${firebaseJson}. The "serviceId":"${rewriteConfig.function}" must use only alphanumeric characters and underscores and cannot be longer than 62 characters.`);
+	}
+
 	if (rewriteConfig?.function && // If function, ensure function root-level field is present
 		(!firebaseConfig?.functions || !firebaseConfig.functions?.source || !isString(firebaseConfig.functions.source))) {
 		throw new Error(`Error with config ${firebaseJson}. If you're using Cloud Functions for your SSR rewrite rule, you need to define a "functions.source" field (of type string) at your config root.`);
@@ -107,6 +111,22 @@ export function parseFirebaseConfiguration({hostingSite, sourceRewriteMatch, fir
  */
 export function validCloudRunServiceId(serviceId) {
 	return /^[a-z\d][a-z\d-]+[a-z\d]$/gm.test(serviceId) && serviceId.length < 64;
+}
+
+/**
+ * Cloud Function name rules:
+ * - alphanumeric
+ * - underscore
+ * - max length 62 chars
+ * @param {string} name
+ * @returns {boolean} `true` if valid
+ *
+ * Rules a combination of
+ * - https://github.com/firebase/firebase-tools/blob/1633f4fccbbc1bcbc6216fe13b8e888c8940bde4/src/deploy/functions/validate.ts#L38
+ * - https://github.com/firebase/firebase-tools/blob/2dc7216a498dee2ca7e2acc33d6ba16d5647e27f/src/extractTriggers.js#L18
+ */
+export function validCloudFunctionName(name) {
+	return /^\w{1,62}$/.test(name);
 }
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -51,12 +51,12 @@ export function parseFirebaseConfiguration({hostingSite, sourceRewriteMatch, fir
 		throw new Error(`Error with config ${firebaseJson}. No "hosting[].site" match for ${hostingSite}. Ensure your svelte.config.js adapter config "hostingSite" matches an item in your Firebase config.`);
 	}
 
-	if (!hostingConfig?.public || !isString(hostingConfig.public)) {
+	if (!isString(hostingConfig?.public)) {
 		throw new Error(`Error with config ${firebaseJson}. "hosting[].public" field is required and should be a string. Hosting config with error: ${JSON.stringify(hostingConfig)}`);
 	}
 
-	if (!hostingConfig?.rewrites || !Array.isArray(hostingConfig?.rewrites)) {
-		throw new Error(`Error with config ${firebaseJson}. "hosting[].rewrites" field  required in hosting config and should be an array of object(s). Hosting config with error: ${JSON.stringify(hostingConfig)}`);
+	if (!Array.isArray(hostingConfig?.rewrites)) {
+		throw new TypeError(`Error with config ${firebaseJson}. "hosting[].rewrites" field  required in hosting config and should be an array of object(s). Hosting config with error: ${JSON.stringify(hostingConfig)}`);
 	}
 
 	const rewriteConfig = hostingConfig.rewrites.find(item => {
@@ -83,8 +83,8 @@ export function parseFirebaseConfiguration({hostingSite, sourceRewriteMatch, fir
 		throw new Error(`Error with config ${firebaseJson}. The "serviceId":"${rewriteConfig.function}" must use only alphanumeric characters and underscores and cannot be longer than 62 characters.`);
 	}
 
-	if (rewriteConfig?.function && // If function, ensure function root-level field is present
-		(!firebaseConfig?.functions || !firebaseConfig.functions?.source || !isString(firebaseConfig.functions.source))) {
+	// If function, ensure function root-level field is present
+	if (rewriteConfig?.function && (!firebaseConfig?.functions || !firebaseConfig.functions?.source || !isString(firebaseConfig.functions.source))) {
 		throw new Error(`Error with config ${firebaseJson}. If you're using Cloud Functions for your SSR rewrite rule, you need to define a "functions.source" field (of type string) at your config root.`);
 	}
 

--- a/tests/fixtures/failures/cf_invalid_function_name.json
+++ b/tests/fixtures/failures/cf_invalid_function_name.json
@@ -1,0 +1,14 @@
+{
+	"hosting": {
+		"public": "app",
+		"rewrites": [
+			{
+				"source": "**",
+				"function": "invalid-func-name"
+			}
+		]
+	},
+	"functions": {
+		"source": "functions"
+	}
+}

--- a/tests/index.test.mjs
+++ b/tests/index.test.mjs
@@ -150,6 +150,8 @@ test(
 	}
 );
 
+// TODO: test funciton name invalid
+
 test(
 	'Firebase config w Cloud Functions & single site missing top-level functions',
 	t => {
@@ -191,7 +193,9 @@ test('Cloud Run serviceId with invalid non-dash (_) symbol', t => {
 });
 
 test('Cloud Run serviceId with invalid length', t => {
-	const result = validCloudRunServiceId('onetwothreefourfiveonetwothreefourfiveonetwothreefourfiveonetwothreefourfive');
+	const result = validCloudRunServiceId('aCloudFunctionsFunctionNameThatIsSeventyFiveCharactersLongWhichIsMoreThan63');
 	t.is(result, false);
 });
 
+// ValidCloudFunctionName
+// TODO: test function name validation

--- a/tests/index.test.mjs
+++ b/tests/index.test.mjs
@@ -1,7 +1,7 @@
 import test from 'ava';
 import path from 'path';
 import {fileURLToPath} from 'url';
-import {parseFirebaseConfiguration, validCloudRunServiceId} from '../src/utils.js';
+import {parseFirebaseConfiguration, validCloudFunctionName, validCloudRunServiceId} from '../src/utils.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -150,7 +150,14 @@ test(
 	}
 );
 
-// TODO: test funciton name invalid
+test(
+	'Firebase config w Cloud Function invalid name',
+	t => {
+		const config = {hostingSite: undefined, sourceRewriteMatch: '**', firebaseJson: path.join(__dirname, 'fixtures/failures/cf_invalid_function_name.json')};
+		const error = t.throws(() => parseFirebaseConfiguration(config));
+		t.is(error.message, `Error with config ${__dirname}/fixtures/failures/cf_invalid_function_name.json. The "serviceId":"invalid-func-name" must use only alphanumeric characters and underscores and cannot be longer than 62 characters.`);
+	}
+);
 
 test(
 	'Firebase config w Cloud Functions & single site missing top-level functions',
@@ -198,4 +205,17 @@ test('Cloud Run serviceId with invalid length', t => {
 });
 
 // ValidCloudFunctionName
-// TODO: test function name validation
+test('Cloud Function name with valid chars', t => {
+	const result = validCloudFunctionName('lowercase_UPPERCASE_0123456789');
+	t.is(result, true);
+});
+
+test('Cloud Function name with invalid dash', t => {
+	const result = validCloudFunctionName('is-invalid');
+	t.is(result, false);
+});
+
+test('Cloud Function name with invalid length', t => {
+	const result = validCloudFunctionName('aCloudFunctionsFunctionNameThatIsSeventyFiveCharactersLongWhichIsMoreThan63');
+	t.is(result, false);
+});


### PR DESCRIPTION
# Summary

- [x] Cloud Function support
- [x] Cloud Function validation
- [x] test new error cases 

## Other Information

The implementation here uses the same hack used in `adapter-vercel` and others to allow using `import` syntax in the CJS environment of Cloud Functions working around the issue of #16 