### PR TITLE
fix: use searchParams in handler.js

### DIFF
--- a/src/files/handler.js
+++ b/src/files/handler.js
@@ -1,9 +1,9 @@
-import {URL, URLSearchParams} from 'url';
+import {URL} from 'url';
 import {get_body as getBody} from '@sveltejs/app-utils/http'; // eslint-disable-line node/file-extension-in-import
 
 const svelteKit = async (request, response) => {
 	const host = `${request.headers['x-forwarded-proto']}://${request.headers.host}`;
-	const {pathname, query = ''} = new URL(request.url || '', host);
+	const {pathname, searchParams} = new URL(request.url || '', host);
 
 	const {render} = await import('./app.mjs');
 
@@ -12,7 +12,7 @@ const svelteKit = async (request, response) => {
 		method: request.method,
 		headers: request.headers,
 		path: pathname,
-		query: new URLSearchParams(query),
+		query: searchParams,
 		body: await getBody(request)
 	});
 


### PR DESCRIPTION
Hi,
Thank you for a great library!

## Summary
I change code in `src/files/handler.js`: use not query but searchParams.

## Why
`query` is undefined in URL, so `page.query` property in load function always null.

`routes/foo.svelte`
```ts
<script lang="ts" context="module">
  import type { Load } from '@sveltejs/kit'
  export async function load({ page, fetch }: Parameters<Load>[0]) {
     const bar = page.query.get('xxx')  // If we access `http://***/?bar=123`, bar always null
  }
  ...
</script>
```