### PR TITLE
fix: remove unused pnpm run build cmd from workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,6 @@ jobs:
           before_install: bash -c '${ASDF_DATA_DIR:=$HOME/.asdf}/plugins/nodejs/bin/import-release-team-keyring'
       - name: Install dependencies
         run: pnpm install
-      - name: Build svelte-adapter-firebase
-        run: pnpm run build
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Summary

<!-- Provide a general description of the code changes in your pull request. -->

The release workflow is broken on `main` because there is no `package.json.scripts.build` script as it was removed in #39. This change should have been made in #39 too.
