### PR TITLE
fix: handle empty deps when cloud run target

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -116,7 +116,7 @@ async function adaptToCloudRun({utils, serviceId, region, cloudRunBuildDir}) {
 		pkgjson.dependencies = {};
 	}
 
-	pkgjson.dependencies['@google-cloud/functions-framework'] = '^1.7.1'; // Peer-dep of this adapter instead?
+	pkgjson.dependencies['@google-cloud/functions-framework'] = '^1.7.1';
 	pkgjson.engines = {node: '14'};
 	delete pkgjson.type;
 	const data = JSON.stringify(pkgjson, null, 2);

--- a/src/index.js
+++ b/src/index.js
@@ -110,8 +110,12 @@ async function adaptToCloudRun({utils, serviceId, region, cloudRunBuildDir}) {
 	utils.log.info(`Writing Cloud Run service to ./${serverOutputDir}`);
 
 	// Prepare Cloud Run package.json - read SvelteKit App 'package.json', modify the JSON, write to serverOutputDir
-	const pkgjson = JSON.parse(readFileSync('package.json', 'utf-8'));
+	const pkgjson = JSON.parse(readFileSync(fileURLToPath(new URL('package.json', import.meta.url)), 'utf-8'));
 	pkgjson.scripts.start = 'functions-framework --target=default';
+	if (pkgjson.dependencies === undefined) {
+		pkgjson.dependencies = {};
+	}
+
 	pkgjson.dependencies['@google-cloud/functions-framework'] = '^1.7.1'; // Peer-dep of this adapter instead?
 	pkgjson.engines = {node: '14'};
 	delete pkgjson.type;


### PR DESCRIPTION
# Summary

<!-- Provide a general description of the code changes in your pull request. -->

The SvelteKit template does not have a `dependencies` field in it's `package.json` which was required by the Cloud Run codepath. We will now add an empty `dependencies` field when it is not present.

Fixes: #34 

## Other Information

<!-- If there is anything else that is relevant to your pull request include that information here. -->

<!--Thank you for contributing to svelte-adapter-firebase! -->

e2e tests should pick this up.