### PR TITLE
fix: treat `firebase.json` as root dir for Firebase resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ In your standard SvelteKit project:
 - `npm run build`
 - Follow further instructions output by the adapter to prepare for deployment.
 
-This adapter reads your `firebase.json` to determine if the Firebase Hosting site is using Cloud Functions or Cloud Run and outputs the server pieces accordingly. Static assets are output to the `public` directory for the Hosting site config.
+This adapter reads `firebase.json` to determine if the Firebase Hosting site is using Cloud Functions or Cloud Run and outputs the server pieces accordingly. Static assets are output to the directory for the Hosting site field `public` configured in `firebase.json`.
 
 Please read the docs carefully!
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Adapter options:
   - path to your `firebase.json`, relative from where `svelte build` is called
   - default: `./firebase.json`
 - `cloudRunBuildDir`
-  - output dir of Cloud Run service, relative from your svelte app
+  - output dir of Cloud Run service, relative from the `firebaseJson` location
   - default: `./.${run.serviceId}` where `run.serviceId` is pulled from the `firebase.json` rewrite rule
 
 ## Details

--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,6 @@ const entrypoint = function ({
 				await adaptToCloudRun({utils, ...cloudRun, firebaseJsonDir, cloudRunBuildDir});
 			}
 
-			utils.log.info(`Clearing dirs for new build: ${publicDir}`);
 			utils.rimraf(publicDir);
 
 			utils.log.minor(`Prerendering static pages to: ${publicDir}`);
@@ -150,17 +149,13 @@ async function prepareEntrypoint({utils, serverOutputDir}) {
 	// TODO: SvelteKit may add utils.tmpdir() which would replace this hardcoded path
 	const temporaryDir = path.join('.svelte-kit', 'firebase');
 
-	utils.log.info(`Clearing dirs for new build: ${temporaryDir}`);
 	utils.rimraf(temporaryDir);
-	utils.log.info(`Clearing dirs for new build: ${serverOutputDir}`);
 	utils.rimraf(serverOutputDir);
 
 	const handlerSource = path.join(fileURLToPath(new URL('./files', import.meta.url)), 'handler.js');
 	const handlerDest = path.join(temporaryDir, 'handler.js');
-	utils.log.info(`Copying adapter handler to ${handlerDest}`);
 	utils.copy(handlerSource, handlerDest);
 
-	utils.log.info('Compiling handler.js with SvelteKit server via esbuild');
 	await esbuild.build({
 		entryPoints: [path.join(temporaryDir, 'handler.js')],
 		outfile: path.join(serverOutputDir, 'index.js'),

--- a/src/utils.js
+++ b/src/utils.js
@@ -24,7 +24,7 @@ function isString(parameter) {
  * }}
  */
 function parseFirebaseConfiguration({hostingSite, sourceRewriteMatch, firebaseJson}) {
-	firebaseJson = path.resolve(firebaseJson); // Should this be fileURLToPath for portability???
+	firebaseJson = path.resolve(firebaseJson);
 	if (!existsSync(firebaseJson)) {
 		throw new Error(`File ${firebaseJson} does not exist. The provided file should exist and be a Firebase JSON config.`);
 	}

--- a/src/utils.js
+++ b/src/utils.js
@@ -24,6 +24,7 @@ function isString(parameter) {
  * }}
  */
 function parseFirebaseConfiguration({hostingSite, sourceRewriteMatch, firebaseJson}) {
+	firebaseJson = path.resolve(firebaseJson); // Should this be fileURLToPath for portability???
 	if (!existsSync(firebaseJson)) {
 		throw new Error(`File ${firebaseJson} does not exist. The provided file should exist and be a Firebase JSON config.`);
 	}
@@ -99,13 +100,13 @@ function parseFirebaseConfiguration({hostingSite, sourceRewriteMatch, firebaseJs
 	return {
 		functions: rewriteConfig?.function ? {
 			name: rewriteConfig.function,
-			source: firebaseConfig.functions.source
+			source: path.join(path.dirname(firebaseJson), firebaseConfig.functions.source)
 		} : false,
 		cloudRun: rewriteConfig?.run ? {
 			serviceId: rewriteConfig.run.serviceId,
 			region: rewriteConfig.run?.region || 'us-central1'
 		} : false,
-		publicDir: hostingConfig.public
+		publicDir: path.join(path.dirname(firebaseJson), hostingConfig.public)
 	};
 }
 

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,5 +1,6 @@
 import test from 'ava';
 import {fileURLToPath} from 'url';
+import path from 'path';
 import {parseFirebaseConfiguration, validCloudFunctionName, validCloudRunServiceId} from '../src/utils.js';
 
 // ParseFirebaseConfiguration: Valid configs
@@ -8,7 +9,7 @@ test(
 	t => {
 		const config = {hostingSite: undefined, sourceRewriteMatch: '**', firebaseJson: fileURLToPath(new URL('./fixtures/successes/cf_site.json', import.meta.url))};
 		const result = parseFirebaseConfiguration(config);
-		const expectedResult = {functions: {name: 'some_func', source: 'functions'}, cloudRun: false, publicDir: 'app'};
+		const expectedResult = {functions: {name: 'some_func', source: path.join(path.dirname(config.firebaseJson), 'functions')}, cloudRun: false, publicDir: path.join(path.dirname(config.firebaseJson), 'app')};
 
 		t.deepEqual(result, expectedResult);
 	}
@@ -19,7 +20,7 @@ test(
 	t => {
 		const config = {hostingSite: 'app', sourceRewriteMatch: '**', firebaseJson: fileURLToPath(new URL('./fixtures/successes/cf_sites.json', import.meta.url))};
 		const result = parseFirebaseConfiguration(config);
-		const expectedResult = {functions: {name: 'some_func', source: 'functions'}, cloudRun: false, publicDir: 'app'};
+		const expectedResult = {functions: {name: 'some_func', source: path.join(path.dirname(config.firebaseJson), 'functions')}, cloudRun: false, publicDir: path.join(path.dirname(config.firebaseJson), 'app')};
 
 		t.deepEqual(result, expectedResult);
 	}
@@ -30,7 +31,7 @@ test(
 	t => {
 		const config = {hostingSite: undefined, sourceRewriteMatch: '**', firebaseJson: fileURLToPath(new URL('./fixtures/successes/cr_site.json', import.meta.url))};
 		const result = parseFirebaseConfiguration(config);
-		const expectedResult = {functions: false, cloudRun: {serviceId: 'some-service', region: 'us-central1'}, publicDir: 'app'};
+		const expectedResult = {functions: false, cloudRun: {serviceId: 'some-service', region: 'us-central1'}, publicDir: path.join(path.dirname(config.firebaseJson), 'app')};
 
 		t.deepEqual(result, expectedResult);
 	}
@@ -41,7 +42,7 @@ test(
 	t => {
 		const config = {hostingSite: 'app', sourceRewriteMatch: '**', firebaseJson: fileURLToPath(new URL('./fixtures/successes/cr_sites.json', import.meta.url))};
 		const result = parseFirebaseConfiguration(config);
-		const expectedResult = {functions: false, cloudRun: {serviceId: 'some-service', region: 'us-central1'}, publicDir: 'app'};
+		const expectedResult = {functions: false, cloudRun: {serviceId: 'some-service', region: 'us-central1'}, publicDir: path.join(path.dirname(config.firebaseJson), 'app')};
 
 		t.deepEqual(result, expectedResult);
 	}


### PR DESCRIPTION
# Summary

<!-- Provide a general description of the code changes in your pull request. -->

Dirs created by the adapter are expected to be relative to the `firebase.json` file, it is the root location. Currently this is not the case as noted in #33 

To resolve this we must:
- [x] identify `firebase.json` dir as the root
- [x] create the `firebase.json.hosting.public` dir relative to this new root 
- [x] read the `firebase.json.functions.source` dir relative to this new root
- [x] create the `cloudRunBuildDir` dir relative to this new root

Fixes: #33 