### PR TITLE
fix: allow any node package manager to install

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Since SvelteKit is still in Beta, and the Adapter API is _most_ in flux, here is
 
 | Adapter Version | SvelteKit Version |
 | --------------- | ----------------- |
-| `0.6.x`         | `1.0.0-next.100`  |
+| `0.6.3`         | `1.0.0-next.101`  |
 | `0.5.x`         | `1.0.0-next.54`   |
 | `0.4.x`         | `1.0.0-next.46`   |
 | `0.3.x`         | `1.0.0-next.27`   |

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "src"
   ],
   "dependencies": {
-    "@sveltejs/kit": "1.0.0-next.100",
+    "@sveltejs/kit": "1.0.0-next.101",
     "esbuild": "^0.11.18"
   },
   "devDependencies": {
@@ -48,7 +48,6 @@
     "xo": "^0.38.2"
   },
   "scripts": {
-    "preinstall": "npx -y only-allow pnpm",
     "prepare": "husky install",
     "fix": "xo --fix",
     "test": "xo && ava"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ specifiers:
   '@commitlint/config-conventional': ^11.0.0
   '@semantic-release/changelog': ^5.0.1
   '@semantic-release/git': ^9.0.0
-  '@sveltejs/kit': 1.0.0-next.100
+  '@sveltejs/kit': 1.0.0-next.101
   '@types/node': ^14.14.35
   ava: ^3.15.0
   esbuild: ^0.11.18
@@ -15,7 +15,7 @@ specifiers:
   xo: ^0.38.2
 
 dependencies:
-  '@sveltejs/kit': 1.0.0-next.100
+  '@sveltejs/kit': 1.0.0-next.101
   esbuild: 0.11.18
 
 devDependencies:
@@ -682,8 +682,8 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
-  /@sveltejs/kit/1.0.0-next.100:
-    resolution: {integrity: sha512-r8G6bIlmIUiRS8JA5Hp+AASNWuuMTua64JP4i2fPTWSvqm/+F8+ZetXgtFy+RNabu5lU/Ua5YVEwBU6rgFVpDA==}
+  /@sveltejs/kit/1.0.0-next.101:
+    resolution: {integrity: sha512-SwUImLhFmyaDsq7LKRJXPJRIOPa06SWENG7heko5FTRRLMpI/UDFcijjT2ln0Fp+AL9XfSbTHO8QrOflCMbfiQ==}
     engines: {node: '>= 12.17.0'}
     hasBin: true
     peerDependencies:


### PR DESCRIPTION
# Summary

<!-- Provide a general description of the code changes in your pull request. -->

In `0.6.1` we added the `preinstall` script that only allowed using `pnpm` which broke our Buildpack powered Run and Function build steps.

Fixes: #44 

## Other Information

<!-- If there is anything else that is relevant to your pull request include that information here. -->

<!--Thank you for contributing to svelte-adapter-firebase! -->

Bumped kit to `@sveltejs/kit/1.0.0-next.101`