### PR TITLE
docs: rm npx -y flag as its npm@7 only

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ In your standard SvelteKit project:
 ```json
 	"scripts": {
 		"dev": "svelte-kit dev",
-		"build": "npx -y rimraf <dir used in firebase.json.hosting.public> && svelte-kit build --verbose",
+		"build": "npx rimraf <dir used in firebase.json.hosting.public> && svelte-kit build --verbose",
 		...
 ```
 


### PR DESCRIPTION
# Summary

<!-- Provide a general description of the code changes in your pull request. -->

`npx -y rimraf` causes an ambiguous error when not using the correct `npm` version. `-y` flag is new to `npm@7` however most users of this adapter will be using Node.js14 which ships `npm@6` so they will hit this error. 

Fixes: #58 

## Other Information

<!-- If there is anything else that is relevant to your pull request include that information here. -->

<!--Thank you for contributing to svelte-adapter-firebase! -->
