### PR TITLE
fix: static output dir differes from static source dirs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ const entrypoint = function ({
 
 			const svelteConfig = await import(path.join(process.cwd(), 'svelte.config.js'));
 			const svelteStaticDir = path.join(process.cwd(), svelteConfig?.kit?.files?.assets || 'static');
-
+			utils.log.info(`source: ${svelteStaticDir} | dest: ${publicDestDir}`);
 			ensureStaticResourceDirsDiffer({source: svelteStaticDir, dest: publicDestDir});
 
 			if (functions !== false) {

--- a/src/index.js
+++ b/src/index.js
@@ -24,12 +24,10 @@ const entrypoint = function ({
 		async adapt(utils) {
 			const {firebaseJsonDir, functions, cloudRun, publicDir} = parseFirebaseConfiguration({hostingSite, sourceRewriteMatch, firebaseJson});
 
-			const publicDestDir = path.join(firebaseJsonDir, publicDir);
-
 			const svelteConfig = await import(path.join(process.cwd(), 'svelte.config.js'));
 			const svelteStaticDir = path.join(process.cwd(), svelteConfig?.kit?.files?.assets || 'static');
-			utils.log.info(`source: ${svelteStaticDir} | dest: ${publicDestDir}`);
-			ensureStaticResourceDirsDiffer({source: svelteStaticDir, dest: publicDestDir});
+			utils.log.info(`source: ${svelteStaticDir} | dest: ${publicDir}`);
+			ensureStaticResourceDirsDiffer({source: svelteStaticDir, dest: publicDir});
 
 			if (functions !== false) {
 				await adaptToCloudFunctions({utils, ...functions});
@@ -39,14 +37,14 @@ const entrypoint = function ({
 				await adaptToCloudRun({utils, ...cloudRun, firebaseJsonDir, cloudRunBuildDir});
 			}
 
-			utils.log.warn(`Erasing ${publicDestDir} before processing static assets`);
-			utils.rimraf(publicDestDir);
+			utils.log.warn(`Erasing ${publicDir} before processing static assets`);
+			utils.rimraf(publicDir);
 
-			utils.log.minor(`Prerendering static pages to: ${publicDestDir}`);
-			await utils.prerender({dest: publicDestDir});
+			utils.log.minor(`Prerendering static pages to: ${publicDir}`);
+			await utils.prerender({dest: publicDir});
 
-			utils.log.minor(`Writing client application to: ${publicDestDir}`);
-			utils.copy_static_files(publicDestDir);
+			utils.log.minor(`Writing client application to: ${publicDir}`);
+			utils.copy_static_files(publicDir);
 			utils.copy_client_files(publicDir);
 		}
 	};

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ const entrypoint = function ({
 
 			const publicDestDir = path.join(firebaseJsonDir, publicDir);
 
-			const svelteConfig = JSON.parse(readFileSync(path.join(process.cwd(), 'svelte.config.js'), 'utf-8'));
+			const svelteConfig = await import(path.join(process.cwd(), 'svelte.config.js'));
 			const svelteStaticDir = path.join(process.cwd(), svelteConfig?.kit?.files?.assets || 'static');
 
 			ensureStaticResourceDirsDiffer({source: svelteStaticDir, dest: publicDestDir});

--- a/src/index.js
+++ b/src/index.js
@@ -24,9 +24,9 @@ const entrypoint = function ({
 		async adapt(utils) {
 			const {firebaseJsonDir, functions, cloudRun, publicDir} = parseFirebaseConfiguration({hostingSite, sourceRewriteMatch, firebaseJson});
 
+			// Temporary solution until - https://github.com/sveltejs/kit/issues/1435 - is resolved
 			const svelteConfig = await import(path.join(process.cwd(), 'svelte.config.js'));
 			const svelteStaticDir = path.join(process.cwd(), svelteConfig?.kit?.files?.assets || 'static');
-			utils.log.info(`source: ${svelteStaticDir} | dest: ${publicDir}`);
 			ensureStaticResourceDirsDiffer({source: svelteStaticDir, dest: publicDir});
 
 			if (functions !== false) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -151,9 +151,23 @@ function copyFileIfExistsSync(filename, destDir) {
 	}
 }
 
+/**
+ * Ensure provided static asset output dir (firebase.json:hosting.public) is not the same as the source dir
+ * @param {{
+ * 	dest:string
+ * 	source:string
+ * }} param source and destination directory for static assets
+ */
+function ensureStaticResourceDirsDiffer({source, dest}) {
+	if (source === dest) {
+		throw new Error('firebase.json:hosting.public must be a different directory to svelte.config.js:kit.files.assets');
+	}
+}
+
 export {
 	parseFirebaseConfiguration,
 	validCloudRunServiceId,
 	validCloudFunctionName,
-	copyFileIfExistsSync
+	copyFileIfExistsSync,
+	ensureStaticResourceDirsDiffer
 };

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,7 +1,7 @@
 import test from 'ava';
 import {fileURLToPath} from 'url';
 import path from 'path';
-import {parseFirebaseConfiguration, validCloudFunctionName, validCloudRunServiceId} from '../src/utils.js';
+import {ensureStaticResourceDirsDiffer, parseFirebaseConfiguration, validCloudFunctionName, validCloudRunServiceId} from '../src/utils.js';
 
 // ParseFirebaseConfiguration: Valid configs
 test(
@@ -230,3 +230,17 @@ test('Cloud Function name with invalid length', t => {
 	const result = validCloudFunctionName('aCloudFunctionsFunctionNameThatIsSeventyFiveCharactersLongWhichIsMoreThan63');
 	t.is(result, false);
 });
+
+//
+test('Static asset source and dest different dirs', t => {
+	const error = t.notThrows(() => ensureStaticResourceDirsDiffer({source: 'a', dest: 'b'}));
+	t.is(error, undefined);
+});
+
+test(
+	'Static asset source and dest the same dir',
+	t => {
+		const error = t.throws(() => ensureStaticResourceDirsDiffer({source: 'a', dest: 'a'}));
+		t.is(error.message, 'firebase.json:hosting.public must be a different directory to svelte.config.js:kit.files.assets');
+	}
+);


### PR DESCRIPTION
# Summary

<!-- Provide a general description of the code changes in your pull request. -->

- ensure the dirs for `svelte.config.js:kit.files.assets` is different from `firebase.json:hosting.public`

Fixes: #56

## Other Information

<!-- If there is anything else that is relevant to your pull request include that information here. -->

<!--Thank you for contributing to svelte-adapter-firebase! -->
