### PR TITLE
fix: ensure valid cloud function runtime version

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -170,7 +170,8 @@ async function prepareEntrypoint({utils, serverOutputDir}) {
 		entryPoints: [path.join(temporaryDir, 'handler.js')],
 		outfile: path.join(serverOutputDir, 'index.js'),
 		bundle: true,
-		platform: 'node'
+		platform: 'node',
+		target: ['node12']
 	});
 }
 


### PR DESCRIPTION
# Summary

<!-- Provide a general description of the code changes in your pull request. -->

Ensure the Cloud Function runtime is set and is at least Node.js14 for compatibility with SvelteKit.

Fixes: #50 

## Other Information

<!-- If there is anything else that is relevant to your pull request include that information here. -->

<!--Thank you for contributing to svelte-adapter-firebase! -->
