### PR TITLE
fix: instruct firebase deployment alongside Cloud Run

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -146,7 +146,7 @@ async function adaptToCloudRun({utils, serviceId, region, firebaseJsonDir, cloud
 gcloud beta run deploy ${serviceId} --platform managed --region ${region} --source ${serverOutputDir} --allow-unauthenticated
 firebase deploy --only hosting
 +--------------------------------------------------+
-Firebase deployment is required as your static assets may have new hashes after the build you deploy with Cloud Run`
+Firebase deployment is required as your static assets and route manifests may have changed from this build.`
 	);
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -141,10 +141,12 @@ async function adaptToCloudRun({utils, serviceId, region, firebaseJsonDir, cloud
 
 	utils.log.warn(
 		// eslint-disable-next-line indent
-`To deploy your Cloud Run service, run this command:
+`To deploy your Cloud Run service, run both of these commands:
 +--------------------------------------------------+
 gcloud beta run deploy ${serviceId} --platform managed --region ${region} --source ${serverOutputDir} --allow-unauthenticated
-+--------------------------------------------------+`
+firebase deploy --only hosting
++--------------------------------------------------+
+Firebase deployment is required as your static assets may have new hashes after the build you deploy with Cloud Run`
 	);
 }
 


### PR DESCRIPTION
# Summary

<!-- Provide a general description of the code changes in your pull request. -->

Instruct users should also perform a `firebase deploy --only hosting` alongside their Cloud Run deployment as the new build may have produced new static assets, route manifests etc.

Fixes: #30

## Other Information

<!-- If there is anything else that is relevant to your pull request include that information here. -->

<!--Thank you for contributing to svelte-adapter-firebase! -->
