### PR TITLE
fix: improve guide & logging of adapter

### DIFF
--- a/examples/functions_single_site/firebase.json
+++ b/examples/functions_single_site/firebase.json
@@ -5,7 +5,7 @@
 		"rewrites": [
 			{
 				"source": "**",
-				"function": "svelte_function_single_site"
+				"function": "sveltekit"
 			}
 		]
 	},

--- a/examples/functions_single_site/functions/.gitignore
+++ b/examples/functions_single_site/functions/.gitignore
@@ -2,4 +2,4 @@ node_modules/
 
 # Specific to this app's firebase.json
 # ignore SvelteKit build output in Cloud Function
-svelte_function_single_site/
+sveltekit/

--- a/examples/functions_single_site/functions/index.js
+++ b/examples/functions_single_site/functions/index.js
@@ -1,13 +1,13 @@
 const functions = require('firebase-functions');
 
-let svelte_function_single_siteServer;
-exports.svelte_function_single_site = functions.https.onRequest(async (request, response) => {
-	if (!svelte_function_single_siteServer) {
+let sveltekitServer;
+exports.sveltekit = functions.https.onRequest(async (request, response) => {
+	if (!sveltekitServer) {
 		functions.logger.info('Initializing SvelteKit SSR Handler');
-		svelte_function_single_siteServer = require('./svelte_function_single_site/index').default;
+		sveltekitServer = require('./sveltekit/index').default;
 		functions.logger.info('SvelteKit SSR Handler initialised!');
 	}
 
 	functions.logger.info('Requested resource: ' + request.originalUrl);
-	return await svelte_function_single_siteServer(request, response);
+	return sveltekitServer(request, response);
 });

--- a/examples/nested_app_dirs/firebase.json
+++ b/examples/nested_app_dirs/firebase.json
@@ -5,7 +5,7 @@
 		"rewrites": [
 			{
 				"source": "**",
-				"function": "nested_app_dir"
+				"function": "sveltekit"
 			}
 		]
 	},

--- a/examples/nested_app_dirs/functions/.gitignore
+++ b/examples/nested_app_dirs/functions/.gitignore
@@ -2,4 +2,4 @@ node_modules/
 
 # Specific to this app's firebase.json
 # ignore SvelteKit build output in Cloud Function
-nested_app_dir/
+sveltekit/

--- a/examples/nested_app_dirs/functions/index.js
+++ b/examples/nested_app_dirs/functions/index.js
@@ -1,13 +1,13 @@
 const functions = require('firebase-functions');
 
-let nested_app_dirServer;
-exports.nested_app_dir = functions.https.onRequest(async (request, response) => {
-	if (!nested_app_dirServer) {
+let sveltekitServer;
+exports.sveltekit = functions.https.onRequest(async (request, response) => {
+	if (!sveltekitServer) {
 		functions.logger.info('Initializing SvelteKit SSR Handler');
-		nested_app_dirServer = require('./nested_app_dir/index').default;
+		sveltekitServer = require('./sveltekit/index').default;
 		functions.logger.info('SvelteKit SSR Handler initialised!');
 	}
 
 	functions.logger.info('Requested resource: ' + request.originalUrl);
-	return nested_app_dirServer(request, response);
+	return sveltekitServer(request, response);
 });

--- a/examples/run_single_site/.gitignore
+++ b/examples/run_single_site/.gitignore
@@ -5,7 +5,7 @@ node_modules
 
 # Specific to this app's firebase.json
 public/
-.svelte-run-single-site
+.cloudrun
 
 # Logs
 logs

--- a/examples/run_single_site/firebase.json
+++ b/examples/run_single_site/firebase.json
@@ -6,7 +6,7 @@
 			{
 				"source": "**",
 				"run": {
-					"serviceId": "svelte-run-single-site"
+					"serviceId": "cloudrun"
 				}
 			}
 		]

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   ],
   "dependencies": {
     "@sveltejs/kit": "1.0.0-next.107",
-    "esbuild": "^0.11.18"
+    "esbuild": "^0.11.18",
+    "kleur": "^4.1.4"
   },
   "devDependencies": {
     "@commitlint/cli": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   ],
   "dependencies": {
     "@sveltejs/kit": "1.0.0-next.107",
-    "esbuild": "^0.11.18",
+    "esbuild": "^0.11.23",
     "kleur": "^4.1.4"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ specifiers:
   '@sveltejs/kit': 1.0.0-next.107
   '@types/node': ^14.14.35
   ava: ^3.15.0
-  esbuild: ^0.11.18
+  esbuild: ^0.11.23
   husky: ^5.0.8
   kleur: ^4.1.4
   semantic-release: ^17.4.0
@@ -17,7 +17,7 @@ specifiers:
 
 dependencies:
   '@sveltejs/kit': 1.0.0-next.107
-  esbuild: 0.11.18
+  esbuild: 0.11.23
   kleur: 4.1.4
 
 devDependencies:
@@ -2227,14 +2227,14 @@ packages:
       is-symbol: 1.0.3
     dev: true
 
-  /esbuild/0.11.18:
-    resolution: {integrity: sha512-KD7v4N9b5B8bxPUNn/3GA9r0HWo4nJk3iwjZ+2zG1ffg+r8ig+wqj7sW6zgI6Sn4/B2FnbzqWxcAokAGGM5zwQ==}
+  /esbuild/0.11.20:
+    resolution: {integrity: sha512-QOZrVpN/Yz74xfat0H6euSgn3RnwLevY1mJTEXneukz1ln9qB+ieaerRMzSeETpz/UJWsBMzRVR/andBht5WKw==}
     hasBin: true
     requiresBuild: true
     dev: false
 
-  /esbuild/0.11.20:
-    resolution: {integrity: sha512-QOZrVpN/Yz74xfat0H6euSgn3RnwLevY1mJTEXneukz1ln9qB+ieaerRMzSeETpz/UJWsBMzRVR/andBht5WKw==}
+  /esbuild/0.11.23:
+    resolution: {integrity: sha512-iaiZZ9vUF5wJV8ob1tl+5aJTrwDczlvGP0JoMmnpC2B0ppiMCu8n8gmy5ZTGl5bcG081XBVn+U+jP+mPFm5T5Q==}
     hasBin: true
     requiresBuild: true
     dev: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,7 @@ specifiers:
   ava: ^3.15.0
   esbuild: ^0.11.18
   husky: ^5.0.8
+  kleur: ^4.1.4
   semantic-release: ^17.4.0
   typescript: ^4.2.3
   xo: ^0.38.2
@@ -17,6 +18,7 @@ specifiers:
 dependencies:
   '@sveltejs/kit': 1.0.0-next.107
   esbuild: 0.11.18
+  kleur: 4.1.4
 
 devDependencies:
   '@commitlint/cli': 11.0.0
@@ -3836,6 +3838,11 @@ packages:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
     engines: {node: '>=0.10.0'}
     dev: true
+
+  /kleur/4.1.4:
+    resolution: {integrity: sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA==}
+    engines: {node: '>=6'}
+    dev: false
 
   /latest-version/5.1.0:
     resolution: {integrity: sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==}

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,6 @@
 import {copyFileSync, existsSync, readFileSync} from 'fs';
 import path from 'path';
+import {createHash} from 'crypto';
 import kleur from 'kleur';
 
 /**
@@ -364,7 +365,8 @@ function logErrorThrow({why, got, wanted, hint, docs}) {
 
 	console.log(`  See docs: ${docs}`);
 	console.log();
-	throw new Error('See above output.');
+	const errorHash = createHash('md5').update(why + got + wanted + hint + docs).digest('hex');
+	throw new Error(`See above output. Error hash: ${errorHash}`);
 }
 
 export {

--- a/src/utils.js
+++ b/src/utils.js
@@ -30,6 +30,42 @@ function parseFirebaseConfiguration({hostingSite, sourceRewriteMatch, firebaseJs
 		throw new Error(`File ${firebaseJson} does not exist. The provided file should exist and be a Firebase JSON config.`);
 	}
 
+	/**
+	 * Firebase configuration from `firebase.json`. Only required types of the adapter.
+	 * @type {{
+	 * hosting: undefined | {
+	 * 	site: undefined | string,
+	 * 	public: undefined | string,
+	 * 	rewrites: undefined | [
+	 * 		{
+	 * 			source: undefined | string,
+	 * 			function: undefined | string,
+	 * 			run: undefined | {
+	 * 				serviceId: undefined | string,
+	 * 				region: undefined | 'us-central1'
+	 * 			},
+	 * 		}
+	 * 	],
+	 * }[] | {
+	 * 	site: undefined | string,
+	 * 	public: undefined | string,
+	 * 	rewrites: undefined | [
+	 * 		{
+	 * 			source: undefined | string,
+	 * 			function: undefined | string,
+	 * 			run: undefined | {
+	 * 				serviceId: undefined | string,
+	 * 				region: undefined | 'us-central1'
+	 * 			},
+	 * 		}
+	 * 	],
+	 * },
+	 * functions: undefined | {
+	 * 	runtime: undefined | 'nodejs14'
+	 * 	source: undefined | string
+	 * }
+	 * }}
+	 */
 	let firebaseConfig;
 	try {
 		firebaseConfig = JSON.parse(readFileSync(firebaseJson, 'utf-8'));

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,6 @@
 import {copyFileSync, existsSync, readFileSync} from 'fs';
 import path from 'path';
+import kleur from 'kleur';
 
 /**
  * @typedef CloudRunRewriteConfig
@@ -32,6 +33,8 @@ import path from 'path';
 */
 
 /**
+ * Firebase configuration from `firebase.json`. Typed with the types required by the adapter.
+ *
  * @typedef FirebaseConfig
  * @type {object} config
  * @property {undefined|HostingConfig|Array.<HostingConfig>} hosting
@@ -64,12 +67,12 @@ function isString(parameter) {
 function parseFirebaseConfiguration({hostingSite, sourceRewriteMatch, firebaseJson}) {
 	firebaseJson = path.resolve(firebaseJson);
 	if (!existsSync(firebaseJson)) {
-		throw new Error(`File ${firebaseJson} does not exist. The provided file should exist and be a Firebase JSON config.`);
+		const errorMessage = `File ${firebaseJson} does not exist.
+The provided file should exist and be a Firebase JSON config.`;
+		throw new Error(errorMessage);
 	}
 
 	/**
-	 * Firebase configuration from `firebase.json`. Typed with the types required by the adapter.
-	 *
 	 * @type {FirebaseConfig}
 	 */
 	let firebaseConfig;
@@ -229,11 +232,23 @@ function ensureCompatibleCloudFunctionVersion({functionsPackageJsonEngine, fireb
 	}
 }
 
+/**
+ * Format message with relative dir on following newline.
+ *
+ * @param {string} message
+ * @param {string} dir
+ * @returns {string} formatted message with relative dir on following newline
+ */
+function logRelativeDir(message, dir) {
+	return `${message}:\n\t${kleur.italic(path.relative(process.cwd(), dir))}`;
+}
+
 export {
+	copyFileIfExistsSync,
+	ensureCompatibleCloudFunctionVersion,
+	ensureStaticResourceDirsDiffer,
+	logRelativeDir,
 	parseFirebaseConfiguration,
 	validCloudRunServiceId,
-	validCloudFunctionName,
-	copyFileIfExistsSync,
-	ensureStaticResourceDirsDiffer,
-	ensureCompatibleCloudFunctionVersion
+	validCloudFunctionName
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -70,7 +70,7 @@ function parseFirebaseConfiguration({hostingSite, sourceRewriteMatch, firebaseJs
 	if (!existsSync(firebaseJson)) {
 		logErrorThrow({
 			why: 'File does not exist.',
-			got: `${kleur.italic(firebaseJson)}`,
+			got: `${kleur.italic(path.relative(process.cwd(), firebaseJson))}`,
 			hint: kleur.blue(`The adapter requires a ${kleur.italic('firebase.json')} file. The above file is computed using the adapter configuration. If the default adapter config is not working, consider updating it in ${kleur.italic('svelte.config.js')}`),
 			docs: 'https://github.com/jthegedus/svelte-adapter-firebase#configuration-overview'
 		}
@@ -94,7 +94,7 @@ function parseFirebaseConfiguration({hostingSite, sourceRewriteMatch, firebaseJs
 	if (!firebaseConfig?.hosting) {
 		logErrorThrow({
 			why: 'Required field missing from Firebase Configuration file.',
-			got: `fields ${kleur.bold(Object.keys(firebaseConfig).toString())}`,
+			got: Object.keys(firebaseConfig) && `fields ${kleur.bold(Object.keys(firebaseConfig).toString())}`,
 			wanted: `${kleur.bold('"hosting"')}`,
 			hint: 'Add the field or fix the typo in your ' + kleur.italic('firebase.json') + ' file',
 			docs: 'https://firebase.google.com/docs/hosting/full-config#firebase-json_example'
@@ -112,7 +112,7 @@ function parseFirebaseConfiguration({hostingSite, sourceRewriteMatch, firebaseJs
 					why: `Multiple hosting configurations found, which requires each to have a ${kleur.bold('"site"')} field, one does not.`,
 					got: `\n${kleur.bold(JSON.stringify(item, null, 2))}`,
 					wanted: `Field named ${kleur.bold('"site": "<site_name>"')}`,
-					hint: 'Add the "site" field to the above Hosting Configuration in ' + kleur.italic(`${firebaseJson}`),
+					hint: 'Add the "site" field to the above Hosting Configuration in ' + kleur.italic('firebase.json'),
 					docs: 'https://firebase.google.com/docs/hosting/multisites'
 				});
 			}

--- a/src/utils.js
+++ b/src/utils.js
@@ -67,8 +67,7 @@ function isString(parameter) {
 function parseFirebaseConfiguration({hostingSite, sourceRewriteMatch, firebaseJson}) {
 	firebaseJson = path.resolve(firebaseJson);
 	if (!existsSync(firebaseJson)) {
-		const errorMessage = `File ${firebaseJson} does not exist.
-The provided file should exist and be a Firebase JSON config.`;
+		const errorMessage = `File ${firebaseJson} does not exist. The provided file should exist and be a Firebase JSON config.`;
 		throw new Error(errorMessage);
 	}
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -67,8 +67,13 @@ function isString(parameter) {
 function parseFirebaseConfiguration({hostingSite, sourceRewriteMatch, firebaseJson}) {
 	firebaseJson = path.resolve(firebaseJson);
 	if (!existsSync(firebaseJson)) {
-		const errorMessage = `File ${firebaseJson} does not exist. The provided file should exist and be a Firebase JSON config.`;
-		throw new Error(errorMessage);
+		logErrorThrow({
+			why: 'File does not exist.',
+			got: `${kleur.italic(firebaseJson)}`,
+			hint: kleur.blue(`The adapter requires a ${kleur.italic('firebase.json')} file. The above file is computed using the adapter configuration. If the default adapter config is not working, consider updating it in ${kleur.italic('svelte.config.js')}`),
+			docs: 'https://github.com/jthegedus/svelte-adapter-firebase#configuration-overview'
+		}
+		);
 	}
 
 	/**
@@ -78,11 +83,21 @@ function parseFirebaseConfiguration({hostingSite, sourceRewriteMatch, firebaseJs
 	try {
 		firebaseConfig = JSON.parse(readFileSync(firebaseJson, 'utf-8'));
 	} catch (error) {
-		throw new Error(`Error parsing ${firebaseJson}. ${error.message}`);
+		logErrorThrow({
+			why: `Error parsing ${kleur.italic('firebase.json')}`,
+			got: error.message,
+			docs: 'https://jsonlint.com/ & https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse'
+		});
 	}
 
 	if (!firebaseConfig?.hosting) {
-		throw new TypeError(`Error with config ${firebaseJson}. "hosting" field required.`);
+		logErrorThrow({
+			why: 'Required field missing from Firebase Configuration file.',
+			got: `fields ${kleur.bold(Object.keys(firebaseConfig).toString())}`,
+			wanted: `${kleur.bold('"hosting"')}`,
+			hint: 'Add the field or fix the typo in your ' + kleur.italic('firebase.json') + ' file',
+			docs: 'https://firebase.google.com/docs/hosting/full-config#firebase-json_example'
+		});
 	}
 
 	// Force "hosting" field to be array
@@ -92,7 +107,13 @@ function parseFirebaseConfiguration({hostingSite, sourceRewriteMatch, firebaseJs
 	if (firebaseHostingConfig.length > 1) {
 		for (const item of firebaseHostingConfig) {
 			if (!item.site) {
-				throw new Error(`Error with config ${firebaseJson}. "hosting" configs should identify their "site" name as Firebase supports multiple sites. This site config does not ${JSON.stringify(item)}`);
+				logErrorThrow({
+					why: `Multiple hosting configurations found, which requires each to have a ${kleur.bold('"site"')} field, one does not.`,
+					got: `\n${kleur.bold(JSON.stringify(item, null, 2))}`,
+					wanted: `Field named ${kleur.bold('"site": "<site_name>"')}`,
+					hint: 'Add the "site" field to the above Hosting Configuration in ' + kleur.italic(`${firebaseJson}`),
+					docs: 'https://firebase.google.com/docs/hosting/multisites'
+				});
 			}
 		}
 	}
@@ -102,15 +123,45 @@ function parseFirebaseConfiguration({hostingSite, sourceRewriteMatch, firebaseJs
 		firebaseHostingConfig.find(item => item.site === hostingSite);
 
 	if (!hostingConfig) {
-		throw new Error(`Error with config ${firebaseJson}. No "hosting[].site" match for ${hostingSite}. Ensure your svelte.config.js adapter config "hostingSite" matches an item in your Firebase config.`);
+		if (!hostingSite) {
+			logErrorThrow({
+				why: `Multiple hosting configurations found but no "${kleur.bold('hostingSite')}" specified in ${kleur.italic('svelte.config.js')} adapter config."`,
+				got: kleur.bold(`"hostingSite": ${hostingSite}`),
+				wanted: kleur.bold('"hostingSite": "<site_name>"') + ` in ${kleur.italic('svelte.config.js')} adapter config`,
+				docs: 'https://github.com/jthegedus/svelte-adapter-firebase#configuration-overview'
+			});
+		}
+
+		const hostingConfigSiteValues = firebaseHostingConfig.map(item => {
+			return {site: item.site};
+		});
+		logErrorThrow({
+			why: `No ${kleur.bold('"hosting[].site"')} match for found for ${kleur.bold(`"${hostingSite}"`)}`,
+			got: `"hosting[].site" values -\n${kleur.bold(JSON.stringify(hostingConfigSiteValues, null, 2))}`,
+			wanted: `One to be ${kleur.bold(`{"site": "${hostingSite}"}`)}`,
+			hint: `Update adapter config "${kleur.bold('hostingSite')}" in ${kleur.italic('svelte.config.js')} to match one of the above Hosting configs.`,
+			docs: 'https://github.com/jthegedus/svelte-adapter-firebase#configuration-overview'
+		});
 	}
 
 	if (!isString(hostingConfig?.public)) {
-		throw new Error(`Error with config ${firebaseJson}. "hosting[].public" field is required and should be a string. Hosting config with error: ${JSON.stringify(hostingConfig)}`);
+		logErrorThrow({
+			why: 'Required "hosting.public" field not found for hosting configuration',
+			got: `Hosting Configuration -\n${JSON.stringify(hostingConfig, null, 2)}`,
+			wanted: '"public": "<some_dir>"',
+			hint: 'Add a "public" field to the matched hosting config in firebase.json',
+			docs: 'https://firebase.google.com/docs/hosting/full-config#public'
+		});
 	}
 
 	if (!Array.isArray(hostingConfig?.rewrites)) {
-		throw new TypeError(`Error with config ${firebaseJson}. "hosting[].rewrites" field  required in hosting config and should be an array of object(s). Hosting config with error: ${JSON.stringify(hostingConfig)}`);
+		logErrorThrow({
+			why: 'Required "hosting[].rewrites" field not found for hosting configuration',
+			got: `Hosting Configuration -\n${JSON.stringify(hostingConfig, null, 2)}`,
+			wanted: '"rewrites": [{...}]',
+			hint: `Hosting conifig requires a rewrites array with either Cloud Run or Cloud Function with rewrite rule matching "source":"${sourceRewriteMatch}"`,
+			docs: 'https://firebase.google.com/docs/hosting/full-config#rewrite-functions'
+		});
 	}
 
 	const rewriteConfig = hostingConfig.rewrites.find(item => {
@@ -118,28 +169,62 @@ function parseFirebaseConfiguration({hostingSite, sourceRewriteMatch, firebaseJs
 	});
 
 	if (!rewriteConfig) {
-		throw new Error(`Error with config ${firebaseJson}. "hosting[].rewrites[*]" does not contain a config with "source":"${sourceRewriteMatch}" and either "function" or "run". Is your "sourceRewriteMatch" in svelte.config.js correct?`);
+		logErrorThrow({
+			why: `Required "hosting[].rewrites[]" does not contain a config with "source":"${sourceRewriteMatch} and either "function":"<func_name>" or "run":{...} entries`,
+			got: `Hosting Configuration -\n${JSON.stringify(hostingConfig, null, 2)}`,
+			wanted: '"rewrites": [{...}]',
+			hint: `Hosting conifig requires a rewrites array with rules for either Cloud Run or Cloud Function with "source":"${sourceRewriteMatch}"`,
+			docs: 'https://firebase.google.com/docs/hosting/full-config#rewrite-functions'
+		});
 	}
 
 	if (rewriteConfig?.run && (!rewriteConfig.run.serviceId || !isString(rewriteConfig.run.serviceId))) {
-		throw new Error(`Error with config ${firebaseJson}. Cloud Run rewrite configuration missing required field "serviceId". Rewrite config with error: ${JSON.stringify(rewriteConfig)}`);
+		logErrorThrow({
+			why: 'Required "serviceId" field not found for Cloud Run rewrite rule',
+			got: `Rewrite rule -\n${JSON.stringify(rewriteConfig, null, 2)}`,
+			wanted: '"serviceId": "<cloud run service name>"',
+			hint: 'Add the field or fix the typo for the rewrite rule in the ' + kleur.italic('firebase.json') + ' file',
+			docs: 'https://firebase.google.com/docs/hosting/full-config#rewrite-cloud-run-container'
+		});
 	}
 
 	if (rewriteConfig?.run && !validCloudRunServiceId(rewriteConfig.run.serviceId)) {
-		throw new Error(`Error with config ${firebaseJson}. The "serviceId":"${rewriteConfig.run.serviceId}" must use only lowercase alphanumeric characters and dashes, cannot begin or end with a dash, and cannot be longer than 63 characters.`);
+		logErrorThrow({
+			why: 'Cloud Run "serviceId" is invalid',
+			got: `${rewriteConfig.run.serviceId}`,
+			hint: 'Cloud Run "serviceId" must use only lowercase alphanumeric characters and dashes, cannot begin or end with a dash, and cannot be longer than 63 characters. Update ' + kleur.italic('firebase.json') + ' accordingly.',
+			docs: 'https://firebase.google.com/docs/hosting/full-config#rewrite-cloud-run-container'
+		});
 	}
 
 	if (rewriteConfig?.run && rewriteConfig?.run?.region && rewriteConfig.run.region !== 'us-central1') {
-		throw new Error(`Error with config ${firebaseJson}. Firebase Hosting rewrites only support "regions":"us-central1" (docs - https://firebase.google.com/docs/functions/locations#http_and_client-callable_functions). Change "${rewriteConfig.run.region}" accordingly.`);
+		logErrorThrow({
+			why: 'Cloud Run "region" is invalid',
+			got: `\n${JSON.stringify(rewriteConfig.run, null, 2)}`,
+			wanted: '"region": "us-central1"',
+			hint: 'Firebase Hosting rewrites only support "regions":"us-central1". Update ' + kleur.italic('firebase.json') + ' accordingly.',
+			docs: 'https://firebase.google.com/docs/functions/locations#http_and_client-callable_functions'
+		});
 	}
 
 	if (rewriteConfig?.function && !validCloudFunctionName(rewriteConfig.function)) {
-		throw new Error(`Error with config ${firebaseJson}. The "serviceId":"${rewriteConfig.function}" must use only alphanumeric characters and underscores and cannot be longer than 62 characters.`);
+		logErrorThrow({
+			why: 'Function name for rewrite rule is invalid',
+			got: `\n${JSON.stringify(rewriteConfig.function, null, 2)}`,
+			hint: 'Function name must use only alphanumeric characters and underscores and cannot be longer than 62 characters. Update ' + kleur.italic('firebase.json') + ' accordingly.',
+			docs: 'https://firebase.google.com/docs/hosting/full-config#rewrite-functions'
+		});
 	}
 
 	// If function, ensure function root-level field is present
 	if (rewriteConfig?.function && (!firebaseConfig?.functions || !firebaseConfig.functions?.source || !isString(firebaseConfig.functions.source))) {
-		throw new Error(`Error with config ${firebaseJson}. If you're using Cloud Functions for your SSR rewrite rule, you need to define a "functions.source" field (of type string) at your config root.`);
+		logErrorThrow({
+			why: 'Required "functions.source" field missing from Firebase Configuration file',
+			got: `Firebase Configuration -\n${JSON.stringify(firebaseConfig, null, 2)}`,
+			wanted: `${kleur.bold('"functions": { "source": "<functions dir>"}')}`,
+			hint: 'Add the field or fix the typo in your ' + kleur.italic('firebase.json') + ' file',
+			docs: 'https://firebase.google.com/docs/functions/manage-functions#deploy_functions'
+		});
 	}
 
 	return {
@@ -205,7 +290,11 @@ function copyFileIfExistsSync(filename, destDir) {
  */
 function ensureStaticResourceDirsDiffer({source, dest}) {
 	if (source === dest) {
-		throw new Error('firebase.json:hosting.public must be a different directory to svelte.config.js:kit.files.assets');
+		logErrorThrow({
+			why: 'firebase.json:hosting.public must be a different directory to svelte.config.js:kit.files.assets',
+			hint: 'Ideally keep svelte.config.js kit.files.assets as "static" and firebase.json:hosting.public as "public"',
+			docs: 'https://github.com/jthegedus/svelte-adapter-firebase/issues/22#issuecomment-831170396'
+		});
 	}
 }
 
@@ -227,7 +316,11 @@ function ensureCompatibleCloudFunctionVersion({functionsPackageJsonEngine, fireb
 	];
 
 	if (!validPackageJsonValues.includes(functionsPackageJsonEngine) && !validFirebaseJsonValues.includes(firebaseJsonFunctionsRuntime)) {
-		throw new Error(`SvelteKit on Cloud Functions requires Node.js 14 or newer runtime. Set this in "package.json:engines.node" with one of "${validPackageJsonValues}" or "firebase.json:functions.runtime" with one of "${validFirebaseJsonValues}" - see the docs https://firebase.google.com/docs/functions/manage-functions#set_nodejs_version`);
+		logErrorThrow({
+			why: 'Node.js runtime not supported. SvelteKit on Cloud Functions requires Node.js 14 or newer runtime.',
+			hint: `Set this in "package.json:engines.node" with one of "${validPackageJsonValues}" or "firebase.json:functions.runtime" with one of "${validFirebaseJsonValues}"`,
+			docs: 'https://firebase.google.com/docs/functions/manage-functions#set_nodejs_version'
+		});
 	}
 }
 
@@ -240,6 +333,38 @@ function ensureCompatibleCloudFunctionVersion({functionsPackageJsonEngine, fireb
  */
 function logRelativeDir(message, dir) {
 	return `${message}:\n\t${kleur.italic(path.relative(process.cwd(), dir))}`;
+}
+
+/**
+ * Log formatted error before `throw new Error()`
+ *
+ * @param {{
+ * 	why: string,
+ * 	got?: string,
+ * 	wanted?: string,
+ * 	hint?: string,
+ * 	docs: string,
+ * }} params
+ */
+function logErrorThrow({why, got, wanted, hint, docs}) {
+	console.log();
+	console.log(kleur.red(`  Error: ${why}`));
+
+	if (got) {
+		console.log(`  Got: ${got}`);
+	}
+
+	if (wanted) {
+		console.log(`  Wanted: ${wanted}`);
+	}
+
+	if (hint) {
+		console.log(kleur.blue(`  Hint: ${hint}`));
+	}
+
+	console.log(`  See docs: ${docs}`);
+	console.log();
+	throw new Error('See above output.');
 }
 
 export {

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,6 +2,43 @@ import {copyFileSync, existsSync, readFileSync} from 'fs';
 import path from 'path';
 
 /**
+ * @typedef CloudRunRewriteConfig
+ * @type {object} cloudrun
+ * @property {undefined|string} cloudrun.serviceId
+ * @property {undefined|'us-central1'} cloudrun.region
+ */
+
+/**
+ * @typedef HostingRewriteConfig
+ * @type {object} rewrite
+ * @property {undefined|string} rewrite.source
+ * @property {undefined|string} rewrite.function
+ * @property {undefined|CloudRunRewriteConfig} rewrite.run
+ */
+
+/**
+ * @typedef HostingConfig
+ * @type {object} hosting
+ * @property {undefined|string} hosting.site
+ * @property {undefined|string} hosting.public
+ * @property {undefined|Array.<HostingRewriteConfig>} hosting.rewrites
+ */
+
+/**
+ * @typedef FunctionsConfig
+ * @type {object} functions
+ * @property {undefined|string} functions.source
+ * @property {undefined|'nodejs14'} functions.runtime
+*/
+
+/**
+ * @typedef FirebaseConfig
+ * @type {object} config
+ * @property {undefined|HostingConfig|Array.<HostingConfig>} hosting
+ * @property {undefined|FunctionsConfig} functions
+ */
+
+/**
  *
  * @param {any} parameter
  * @returns {boolean} true if param is a string
@@ -22,7 +59,7 @@ function isString(parameter) {
  * 	cloudRun: false | { serviceId: string, region: string };
  * 	firebaseJsonDir: string;
  * 	publicDir: string
- * }}
+ * }} Functions or Run config with `public` dir and `firebase.json` root dir
  */
 function parseFirebaseConfiguration({hostingSite, sourceRewriteMatch, firebaseJson}) {
 	firebaseJson = path.resolve(firebaseJson);
@@ -31,40 +68,9 @@ function parseFirebaseConfiguration({hostingSite, sourceRewriteMatch, firebaseJs
 	}
 
 	/**
-	 * Firebase configuration from `firebase.json`. Only required types of the adapter.
-	 * @type {{
-	 * hosting: undefined | {
-	 * 	site: undefined | string,
-	 * 	public: undefined | string,
-	 * 	rewrites: undefined | [
-	 * 		{
-	 * 			source: undefined | string,
-	 * 			function: undefined | string,
-	 * 			run: undefined | {
-	 * 				serviceId: undefined | string,
-	 * 				region: undefined | 'us-central1'
-	 * 			},
-	 * 		}
-	 * 	],
-	 * }[] | {
-	 * 	site: undefined | string,
-	 * 	public: undefined | string,
-	 * 	rewrites: undefined | [
-	 * 		{
-	 * 			source: undefined | string,
-	 * 			function: undefined | string,
-	 * 			run: undefined | {
-	 * 				serviceId: undefined | string,
-	 * 				region: undefined | 'us-central1'
-	 * 			},
-	 * 		}
-	 * 	],
-	 * },
-	 * functions: undefined | {
-	 * 	runtime: undefined | 'nodejs14'
-	 * 	source: undefined | string
-	 * }
-	 * }}
+	 * Firebase configuration from `firebase.json`. Typed with the types required by the adapter.
+	 *
+	 * @type {FirebaseConfig}
 	 */
 	let firebaseConfig;
 	try {

--- a/tests/e2e-healthcheck.sh
+++ b/tests/e2e-healthcheck.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-set -e
-
-res=$(curl localhost:5000/ -o /dev/stderr -w "%{http_code}")
-
-[ "$res" -eq 200 ]

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -55,7 +55,7 @@ test(
 		const firebaseJson = fileURLToPath(new URL('./does_not_exist.json', import.meta.url));
 		const config = {hostingSite: undefined, sourceRewriteMatch: '**', firebaseJson};
 		const error = t.throws(() => parseFirebaseConfiguration(config));
-		t.is(error.message, `File ${firebaseJson} does not exist. The provided file should exist and be a Firebase JSON config.`);
+		t.is(error.message, 'See above output. Error hash: d1c6a473697671d5cb09adbedbc02396');
 	}
 );
 
@@ -65,7 +65,7 @@ test(
 		const firebaseJson = fileURLToPath(new URL('./fixtures/failures/invalid.json', import.meta.url));
 		const config = {hostingSite: undefined, sourceRewriteMatch: '**', firebaseJson};
 		const error = t.throws(() => parseFirebaseConfiguration(config));
-		t.is(error.message, `Error parsing ${firebaseJson}. Unexpected token } in JSON at position 28`);
+		t.is(error.message, 'See above output. Error hash: 1d0b08ec7b33b5d55bbf411fc2c57b3f');
 	}
 );
 
@@ -75,7 +75,7 @@ test(
 		const firebaseJson = fileURLToPath(new URL('./fixtures/failures/missing_hosting.json', import.meta.url));
 		const config = {hostingSite: undefined, sourceRewriteMatch: '**', firebaseJson};
 		const error = t.throws(() => parseFirebaseConfiguration(config));
-		t.is(error.message, `Error with config ${firebaseJson}. "hosting" field required.`);
+		t.is(error.message, 'See above output. Error hash: ee83e47e470ffb64e1022cb1ca373667');
 	}
 );
 
@@ -85,7 +85,7 @@ test(
 		const firebaseJson = fileURLToPath(new URL('./fixtures/failures/sites_missing_rewrites.json', import.meta.url));
 		const config = {hostingSite: undefined, sourceRewriteMatch: '**', firebaseJson};
 		const error = t.throws(() => parseFirebaseConfiguration(config));
-		t.is(error.message, `Error with config ${firebaseJson}. "hosting" configs should identify their "site" name as Firebase supports multiple sites. This site config does not {"public":"some_dir"}`);
+		t.is(error.message, 'See above output. Error hash: 036ac1c936c5737368e75116b19a455c');
 	}
 );
 
@@ -95,7 +95,7 @@ test(
 		const firebaseJson = fileURLToPath(new URL('./fixtures/failures/cf_multi_site_requires_hostingSite.json', import.meta.url));
 		const config = {hostingSite: undefined, sourceRewriteMatch: '**', firebaseJson};
 		const error = t.throws(() => parseFirebaseConfiguration(config));
-		t.is(error.message, `Error with config ${firebaseJson}. No "hosting[].site" match for undefined. Ensure your svelte.config.js adapter config "hostingSite" matches an item in your Firebase config.`);
+		t.is(error.message, 'See above output. Error hash: d57c6b0d358d6b9e0fcdea66d186afa5');
 	}
 );
 
@@ -105,7 +105,7 @@ test(
 		const firebaseJson = fileURLToPath(new URL('./fixtures/failures/site_missing_public.json', import.meta.url));
 		const config = {hostingSite: undefined, sourceRewriteMatch: '**', firebaseJson};
 		const error = t.throws(() => parseFirebaseConfiguration(config));
-		t.is(error.message, `Error with config ${firebaseJson}. "hosting[].public" field is required and should be a string. Hosting config with error: {}`);
+		t.is(error.message, 'See above output. Error hash: cafdfaeb44e29c274fb6f6507b59d82b');
 	}
 );
 
@@ -115,7 +115,7 @@ test(
 		const firebaseJson = fileURLToPath(new URL('./fixtures/failures/site_missing_rewrite.json', import.meta.url));
 		const config = {hostingSite: undefined, sourceRewriteMatch: '**', firebaseJson};
 		const error = t.throws(() => parseFirebaseConfiguration(config));
-		t.is(error.message, `Error with config ${firebaseJson}. "hosting[].rewrites" field  required in hosting config and should be an array of object(s). Hosting config with error: {"public":"app"}`);
+		t.is(error.message, 'See above output. Error hash: 79084ae7cc2229eff3902bb400c0a545');
 	}
 );
 
@@ -125,7 +125,7 @@ test(
 		const firebaseJson = fileURLToPath(new URL('./fixtures/failures/cf_site_rewrite_mismatch.json', import.meta.url));
 		const config = {hostingSite: undefined, sourceRewriteMatch: 'no_match', firebaseJson};
 		const error = t.throws(() => parseFirebaseConfiguration(config));
-		t.is(error.message, `Error with config ${firebaseJson}. "hosting[].rewrites[*]" does not contain a config with "source":"no_match" and either "function" or "run". Is your "sourceRewriteMatch" in svelte.config.js correct?`);
+		t.is(error.message, 'See above output. Error hash: d4567eef86b8f2c7fcf6165d2d0c2aa1');
 	}
 );
 
@@ -135,7 +135,7 @@ test(
 		const firebaseJson = fileURLToPath(new URL('./fixtures/failures/cr_missing_serviceId.json', import.meta.url));
 		const config = {hostingSite: undefined, sourceRewriteMatch: '**', firebaseJson};
 		const error = t.throws(() => parseFirebaseConfiguration(config));
-		t.is(error.message, `Error with config ${firebaseJson}. Cloud Run rewrite configuration missing required field "serviceId". Rewrite config with error: {"source":"**","run":{}}`);
+		t.is(error.message, 'See above output. Error hash: 2a448790e275e60a88cfbfbc457bb6b6');
 	}
 );
 
@@ -145,7 +145,7 @@ test(
 		const firebaseJson = fileURLToPath(new URL('./fixtures/failures/cr_invalid_serviceId.json', import.meta.url));
 		const config = {hostingSite: undefined, sourceRewriteMatch: '**', firebaseJson};
 		const error = t.throws(() => parseFirebaseConfiguration(config));
-		t.is(error.message, `Error with config ${firebaseJson}. "hosting[].public" field is required and should be a string. Hosting config with error: {"rewrites":[{"source":"**","run":{"serviceId":"anInvalidServiceId"}}]}`);
+		t.is(error.message, 'See above output. Error hash: 8c5fa4f640cb1f6fcdf481836dba5f2e');
 	}
 );
 
@@ -155,7 +155,7 @@ test(
 		const firebaseJson = fileURLToPath(new URL('./fixtures/failures/cr_invalid_region.json', import.meta.url));
 		const config = {hostingSite: undefined, sourceRewriteMatch: '**', firebaseJson};
 		const error = t.throws(() => parseFirebaseConfiguration(config));
-		t.is(error.message, `Error with config ${firebaseJson}. Firebase Hosting rewrites only support "regions":"us-central1" (docs - https://firebase.google.com/docs/functions/locations#http_and_client-callable_functions). Change "not-a-region" accordingly.`);
+		t.is(error.message, 'See above output. Error hash: 31df056aa250fdabeb6f6a7f1ffe11d6');
 	}
 );
 
@@ -165,7 +165,7 @@ test(
 		const firebaseJson = fileURLToPath(new URL('./fixtures/failures/cf_invalid_function_name.json', import.meta.url));
 		const config = {hostingSite: undefined, sourceRewriteMatch: '**', firebaseJson};
 		const error = t.throws(() => parseFirebaseConfiguration(config));
-		t.is(error.message, `Error with config ${firebaseJson}. The "serviceId":"invalid-func-name" must use only alphanumeric characters and underscores and cannot be longer than 62 characters.`);
+		t.is(error.message, 'See above output. Error hash: 850cde9e3e5ccc6060499de5e8072677');
 	}
 );
 
@@ -175,7 +175,7 @@ test(
 		const firebaseJson = fileURLToPath(new URL('./fixtures/failures/cf_site_missing_functions.json', import.meta.url));
 		const config = {hostingSite: undefined, sourceRewriteMatch: '**', firebaseJson};
 		const error = t.throws(() => parseFirebaseConfiguration(config));
-		t.is(error.message, `Error with config ${firebaseJson}. If you're using Cloud Functions for your SSR rewrite rule, you need to define a "functions.source" field (of type string) at your config root.`);
+		t.is(error.message, 'See above output. Error hash: 4b77ac38aba658ee1dac748579be8b01');
 	}
 );
 
@@ -241,7 +241,7 @@ test(
 	'Static asset source and dest the same dir',
 	t => {
 		const error = t.throws(() => ensureStaticResourceDirsDiffer({source: 'a', dest: 'a'}));
-		t.is(error.message, 'firebase.json:hosting.public must be a different directory to svelte.config.js:kit.files.assets');
+		t.is(error.message, 'See above output. Error hash: 3d5e040b4d834fbdc1f1763591ad3c68');
 	}
 );
 
@@ -259,20 +259,20 @@ test(
 	'No Function runtime provided',
 	t => {
 		const error = t.throws(() => ensureCompatibleCloudFunctionVersion({}));
-		t.is(error.message, 'SvelteKit on Cloud Functions requires Node.js 14 or newer runtime. Set this in "package.json:engines.node" with one of "14" or "firebase.json:functions.runtime" with one of "nodejs14" - see the docs https://firebase.google.com/docs/functions/manage-functions#set_nodejs_version');
+		t.is(error.message, 'See above output. Error hash: 9e40e7b9761be17831477824c1ecac6d');
 	}
 );
 test(
 	'Invalid Function runtime in package.json',
 	t => {
 		const error = t.throws(() => ensureCompatibleCloudFunctionVersion({functionsPackageJsonEngine: '12'}));
-		t.is(error.message, 'SvelteKit on Cloud Functions requires Node.js 14 or newer runtime. Set this in "package.json:engines.node" with one of "14" or "firebase.json:functions.runtime" with one of "nodejs14" - see the docs https://firebase.google.com/docs/functions/manage-functions#set_nodejs_version');
+		t.is(error.message, 'See above output. Error hash: 9e40e7b9761be17831477824c1ecac6d');
 	}
 );
 test(
 	'Invalid Function runtime in firebase.json',
 	t => {
 		const error = t.throws(() => ensureCompatibleCloudFunctionVersion({firebaseJsonFunctionsRuntime: 'nodejs12'}));
-		t.is(error.message, 'SvelteKit on Cloud Functions requires Node.js 14 or newer runtime. Set this in "package.json:engines.node" with one of "14" or "firebase.json:functions.runtime" with one of "nodejs14" - see the docs https://firebase.google.com/docs/functions/manage-functions#set_nodejs_version');
+		t.is(error.message, 'See above output. Error hash: 9e40e7b9761be17831477824c1ecac6d');
 	}
 );

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -55,7 +55,7 @@ test(
 		const firebaseJson = fileURLToPath(new URL('./does_not_exist.json', import.meta.url));
 		const config = {hostingSite: undefined, sourceRewriteMatch: '**', firebaseJson};
 		const error = t.throws(() => parseFirebaseConfiguration(config));
-		t.is(error.message, 'See above output. Error hash: d1c6a473697671d5cb09adbedbc02396');
+		t.is(error.message, 'See above output. Error hash: 35f0234e50232c6836704e1284bdcfc6');
 	}
 );
 
@@ -85,7 +85,7 @@ test(
 		const firebaseJson = fileURLToPath(new URL('./fixtures/failures/sites_missing_rewrites.json', import.meta.url));
 		const config = {hostingSite: undefined, sourceRewriteMatch: '**', firebaseJson};
 		const error = t.throws(() => parseFirebaseConfiguration(config));
-		t.is(error.message, 'See above output. Error hash: 036ac1c936c5737368e75116b19a455c');
+		t.is(error.message, 'See above output. Error hash: b3f0af4cee86288fefc39535563751d6');
 	}
 );
 


### PR DESCRIPTION
# Summary

<!-- Provide a general description of the code changes in your pull request. -->

The adapter is meant to guide you through the setup, however the error messages and format/log-level are confusing users and making them feel like they made a mistake.

- [x] improve consistency in `examples/`
- [x] type the firebase config better in the parser (only required types added)
- [x] update parser errors to be more of a guide
- [ ] replace hashing test hack or normalize failing tests

Fixes: #68 

## Other Information

<!-- If there is anything else that is relevant to your pull request include that information here. -->

<!--Thank you for contributing to svelte-adapter-firebase! -->

~The error output was moved from the `msg` in `throw new Error(msg)` to `console.log()` calls, so a hash of the string input to `console.log()` was used in tests. This needs to be improved upon later.~