### PR TITLE
fix: use esbuild inject api to ensure exec order & polyfill

### DIFF
--- a/src/files/handler.js
+++ b/src/files/handler.js
@@ -1,5 +1,3 @@
-import '@sveltejs/kit/install-fetch'; // eslint-disable-line import/no-unassigned-import
-
 // TODO: hardcoding the relative location makes this brittle
 import {init, render} from '../output/server/app.js';
 

--- a/src/files/shims.js
+++ b/src/files/shims.js
@@ -1,0 +1,1 @@
+export {fetch, Response, Request, Headers} from '@sveltejs/kit/install-fetch';

--- a/src/index.js
+++ b/src/index.js
@@ -158,7 +158,8 @@ async function prepareEntrypoint({utils, serverOutputDir}) {
 	utils.rimraf(temporaryDir);
 	utils.rimraf(serverOutputDir);
 
-	const handlerSource = path.join(fileURLToPath(new URL('./files', import.meta.url)), 'handler.js');
+	const files = fileURLToPath(new URL('./files', import.meta.url));
+	const handlerSource = path.join(files, 'handler.js');
 	const handlerDest = path.join(temporaryDir, 'handler.js');
 	utils.copy(handlerSource, handlerDest);
 
@@ -166,6 +167,7 @@ async function prepareEntrypoint({utils, serverOutputDir}) {
 		entryPoints: [path.join(temporaryDir, 'handler.js')],
 		outfile: path.join(serverOutputDir, 'index.js'),
 		bundle: true,
+		inject: [path.join(files, 'shims.js')],
 		platform: 'node',
 		target: ['node12']
 	});


### PR DESCRIPTION
# Summary

<!-- Provide a general description of the code changes in your pull request. -->

Use [esbuild inject API](https://esbuild.github.io/api/#inject) as updated in official adapters in https://github.com/sveltejs/kit/pull/1822

>In particular, this guarantees:
> - Execution order before all user/kit code in build output
> - Properly polyfilled bindings for fetch etc

## Other Information

<!-- If there is anything else that is relevant to your pull request include that information here. -->

<!--Thank you for contributing to svelte-adapter-firebase! -->
