### PR TITLE
ci: remove asdf-nodejs release-keyring

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,8 +18,6 @@ jobs:
       - uses: actions/checkout@v2
       - name: install asdf
         uses: asdf-vm/actions/install@v1
-        with:
-          before_install: bash -c '${ASDF_DATA_DIR:=$HOME/.asdf}/plugins/nodejs/bin/import-release-team-keyring'
       - run: pnpm install
       - run: pnpm run test
 
@@ -42,8 +40,6 @@ jobs:
       - name: install asdf
         if: matrix.os != 'windows-latest'
         uses: asdf-vm/actions/install@v1
-        with:
-          before_install: bash -c '${ASDF_DATA_DIR:=$HOME/.asdf}/plugins/nodejs/bin/import-release-team-keyring'
       # START: Windows
       - name: install Node.js on Windows
         if: matrix.os == 'windows-latest'


### PR DESCRIPTION
# Summary

<!-- Provide a general description of the code changes in your pull request. -->

This chore just cleans up the asdf-nodejs keyring config as it is not required anymore

## Other Information

<!-- If there is anything else that is relevant to your pull request include that information here. -->

<!--Thank you for contributing to svelte-adapter-firebase! -->
