### PR TITLE
fix: support nodejs16 env

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -29,7 +29,7 @@ import kleur from 'kleur';
  * @typedef FunctionsConfig
  * @type {object} functions
  * @property {undefined|string} functions.source
- * @property {undefined|'nodejs14'} functions.runtime
+ * @property {undefined|'nodejs14'|'nodejs16'} functions.runtime
 */
 
 /**
@@ -333,17 +333,17 @@ function ensureStaticResourceDirsDiffer({source, dest}) {
  */
 function ensureCompatibleCloudFunctionVersion({functionsPackageJsonEngine, firebaseJsonFunctionsRuntime}) {
 	const validPackageJsonValues = [
-		'14'
-		// "16"
+		'14',
+		'16'
 	];
 	const validFirebaseJsonValues = [
-		'nodejs14'
-		// 'nodejs16'
+		'nodejs14',
+		'nodejs16'
 	];
 
 	if (!validPackageJsonValues.includes(functionsPackageJsonEngine) && !validFirebaseJsonValues.includes(firebaseJsonFunctionsRuntime)) {
 		logErrorThrow({
-			why: 'Node.js runtime not supported. SvelteKit on Cloud Functions requires Node.js 14 or newer runtime.',
+			why: `Node.js runtime not supported. SvelteKit on Cloud Functions requires one of runtime: ${validFirebaseJsonValues}`,
 			hint: `Set this in "package.json:engines.node" with one of "${validPackageJsonValues}" or "firebase.json:functions.runtime" with one of "${validFirebaseJsonValues}"`,
 			docs: 'https://firebase.google.com/docs/functions/manage-functions#set_nodejs_version',
 			hintCode: 1061

--- a/tests/unit/src/utils.test.js
+++ b/tests/unit/src/utils.test.js
@@ -247,11 +247,17 @@ test(
 );
 
 // EnsureCompatibleCloudFunctionVersion
-test('Valid Function runtime version in package.json', () => {
+test('Valid Function runtime (nodejs14) version in package.json', () => {
 	assert.not.throws(() => ensureCompatibleCloudFunctionVersion({functionsPackageJsonEngine: '14'}));
 });
-test('Valid Function runtime version in firebase.json', () => {
+test('Valid Function runtime (nodejs14) version in firebase.json', () => {
 	assert.not.throws(() => ensureCompatibleCloudFunctionVersion({firebaseJsonFunctionsRuntime: 'nodejs14'}));
+});
+test('Valid Function runtime (nodejs16) version in package.json', () => {
+	assert.not.throws(() => ensureCompatibleCloudFunctionVersion({functionsPackageJsonEngine: '16'}));
+});
+test('Valid Function runtime (nodejs16) version in firebase.json', () => {
+	assert.not.throws(() => ensureCompatibleCloudFunctionVersion({firebaseJsonFunctionsRuntime: 'nodejs16'}));
 });
 
 test(


### PR DESCRIPTION
# Summary

<!-- Provide a general description of the code changes in your pull request. -->

Allows use of `nodejs16` runtime environment.

Fixes: #128 

## Other Information

<!-- If there is anything else that is relevant to your pull request include that information here. -->

<!--Thank you for contributing to svelte-adapter-firebase! -->
