### PR TITLE
fix: output entrypoint code without verbose mode

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -69,8 +69,8 @@ const entrypoint = function (options = {}) {
 
 			try {
 				if (!readFileSync(ssrFunc.entrypoint, 'utf-8').includes(`${functions.name} =`)) {
-					utils.log.info(`Add the following Cloud Function to ${ssrFunc.entrypoint}`);
-					utils.log.info(`
+					utils.log.warn(`Add the following Cloud Function to ${ssrFunc.entrypoint}`);
+					utils.log.warn(`
 let ${ssrFunc.svelteSSR};
 exports.${functions.name} = functions.region("us-central1").https.onRequest(async (request, response) => {
 	if (!${ssrFunc.svelteSSR}) {


### PR DESCRIPTION
# Summary

<!-- Provide a general description of the code changes in your pull request. -->

SvelteKit templates no longer include the `--verbose` flag on the `svelte-kit build` `npm` script so users will not see the output unless we increase the log type used.