### PR TITLE
fix: pass null if no req.rawBody

### DIFF
--- a/src/files/firebase-to-svelte-kit.js
+++ b/src/files/firebase-to-svelte-kit.js
@@ -13,7 +13,7 @@ export function toSvelteKitRequest(request) {
 		headers: toSvelteKitHeaders(request.headers),
 		rawBody: request.rawBody
 			? request.rawBody
-			: new Uint8Array(),
+			: null,
 		host,
 		path: pathname,
 		query: searchParameters,

--- a/tests/unit/src/files/firebase-to-svelte-kit.test.js
+++ b/tests/unit/src/files/firebase-to-svelte-kit.test.js
@@ -67,7 +67,7 @@ test('firebase-functions.https.request GET is converted to SvelteKit Incoming re
 			host: 'us-central1-func.cloudfunctions.net',
 			'x-forwarded-proto': 'https',
 		},
-		rawBody: new Uint8Array(),
+		rawBody: null,
 		host: 'https://us-central1-func.cloudfunctions.net',
 		path: '/url',
 		query: new URL('/url?some=thing', 'https://us-central1-func.cloudfunctions.net').searchParams,


### PR DESCRIPTION
# Summary

<!-- Provide a general description of the code changes in your pull request. -->

Pass `rawBody:null` to SvelteKit `render(req)` function as per the changes in https://github.com/sveltejs/kit/pull/2299/files#diff-418712fdcdc80e8bf5cc0e519480d6bc0178a372c82aa3675dddd4870a5988a6R25

Fixes: #127 

## Other Information

<!-- If there is anything else that is relevant to your pull request include that information here. -->

<!--Thank you for contributing to svelte-adapter-firebase! -->

As per https://github.com/firebase/firebase-functions/pull/959 the `firebase-functions.https.Request` type does not align with the upstream Functions Framework type and `req.rawBody` from Firebase is actually optional, so can be nullable, unlike the type information in VSCode indicates.