### PR TITLE
feat: Support for SvelteKit Next 303

### DIFF
--- a/src/files/entry.js
+++ b/src/files/entry.js
@@ -17,10 +17,10 @@ const server = new Server(manifest);
  * @returns {Promise<void>}
  */
 export default async function svelteKit(request, response) {
-  const rendered = await server.respond(toSvelteKitRequest(request));
-  const body = await rendered.text();
+    const rendered = await server.respond(toSvelteKitRequest(request));
+    const body = await rendered.text();
 
-  return rendered
-    ? response.writeHead(rendered.status, rendered.headers).end(body)
-    : response.writeHead(404, 'Not Found').end();
+    return rendered
+        ? response.writeHead(rendered.status, rendered.headers).end(body)
+        : response.writeHead(404, 'Not Found').end();
 }

--- a/src/files/entry.js
+++ b/src/files/entry.js
@@ -17,10 +17,10 @@ const server = new Server(manifest);
  * @returns {Promise<void>}
  */
 export default async function svelteKit(request, response) {
-        const rendered = await server.respond(toSvelteKitRequest(request));
-        const body = await rendered.text();
+	const rendered = await server.respond(toSvelteKitRequest(request));
+	const body = await rendered.text();
 
-        return rendered
-                ? response.writeHead(rendered.status, rendered.headers).end(body)
-                : response.writeHead(404, 'Not Found').end();
+	return rendered
+		? response.writeHead(rendered.status, rendered.headers).end(body)
+		: response.writeHead(404, 'Not Found').end();
 }

--- a/src/files/entry.js
+++ b/src/files/entry.js
@@ -17,10 +17,10 @@ const server = new Server(manifest);
  * @returns {Promise<void>}
  */
 export default async function svelteKit(request, response) {
-    const rendered = await server.respond(toSvelteKitRequest(request));
-    const body = await rendered.text();
+        const rendered = await server.respond(toSvelteKitRequest(request));
+        const body = await rendered.text();
 
-    return rendered
-        ? response.writeHead(rendered.status, rendered.headers).end(body)
-        : response.writeHead(404, 'Not Found').end();
+        return rendered
+                ? response.writeHead(rendered.status, rendered.headers).end(body)
+                : response.writeHead(404, 'Not Found').end();
 }

--- a/src/files/entry.js
+++ b/src/files/entry.js
@@ -1,11 +1,8 @@
-// @ts-expect-error will be resolve by https://github.com/sveltejs/kit/pull/2285
-import * as App from '../output/server/app.js';
-import {toSvelteKitRequest} from './firebase-to-svelte-kit.js';
+import { Server } from 'SERVER';
+import { manifest } from 'MANIFEST';
+import { toSvelteKitRequest } from './firebase-to-svelte-kit.js';
 
-/** @type {import('@sveltejs/kit').App} */
-const app = App;
-
-app.init();
+const server = new Server(manifest);
 
 /**
  * Firebase Cloud Function handler for SvelteKit
@@ -20,9 +17,10 @@ app.init();
  * @returns {Promise<void>}
  */
 export default async function svelteKit(request, response) {
-	const rendered = await app.render(toSvelteKitRequest(request));
+  const rendered = await server.respond(toSvelteKitRequest(request));
+  const body = await rendered.text();
 
-	return rendered
-		? response.writeHead(rendered.status, rendered.headers).end(rendered.body)
-		: response.writeHead(404, 'Not Found').end();
+  return rendered
+    ? response.writeHead(rendered.status, rendered.headers).end(body)
+    : response.writeHead(404, 'Not Found').end();
 }

--- a/src/files/firebase-to-svelte-kit.js
+++ b/src/files/firebase-to-svelte-kit.js
@@ -6,18 +6,15 @@
  */
 export function toSvelteKitRequest(request) {
 	const host = `${request.headers['x-forwarded-proto']}://${request.headers.host}`;
-	const {pathname, searchParams: searchParameters} = new URL(request.url || '', host);
+	const {href, pathname, searchParams: searchParameters} = new URL(request.url || '', host);
 
-	return {
+	return new Request(href, {
 		method: request.method,
 		headers: toSvelteKitHeaders(request.headers),
-		rawBody: request.rawBody
+		body: request.rawBody
 			? request.rawBody
 			: null,
-		host,
-		path: pathname,
-		query: searchParameters,
-	};
+	});
 }
 
 /**

--- a/src/files/firebase-to-svelte-kit.js
+++ b/src/files/firebase-to-svelte-kit.js
@@ -5,16 +5,16 @@
  * @return {import('@sveltejs/kit').IncomingRequest}
  */
 export function toSvelteKitRequest(request) {
-    const host = `${request.headers['x-forwarded-proto']}://${request.headers.host}`;
-    const { href, pathname, searchParams: searchParameters } = new URL(request.url || '', host);
+        const host = `${request.headers['x-forwarded-proto']}://${request.headers.host}`;
+        const { href, pathname, searchParams: searchParameters } = new URL(request.url || '', host);
 
-    return new Request(href, {
-        method: request.method,
-        headers: toSvelteKitHeaders(request.headers),
-        body: request.rawBody
-            ? request.rawBody
-            : null,
-    });
+        return new Request(href, {
+                method: request.method,
+                headers: toSvelteKitHeaders(request.headers),
+                body: request.rawBody
+                        ? request.rawBody
+                        : null,
+        });
 }
 
 /**
@@ -30,15 +30,15 @@ export function toSvelteKitRequest(request) {
  * @returns {Record<string, string>}
  */
 export function toSvelteKitHeaders(headers) {
-    /** @type {Record<string, string>} */
-    const finalHeaders = {};
+        /** @type {Record<string, string>} */
+        const finalHeaders = {};
 
-    // Assume string | string[] types for all values
-    for (const [key, value] of Object.entries(headers)) {
-        finalHeaders[key] = Array.isArray(value)
-            ? value.join(',')
-            : value;
-    }
+        // Assume string | string[] types for all values
+        for (const [key, value] of Object.entries(headers)) {
+                finalHeaders[key] = Array.isArray(value)
+                        ? value.join(',')
+                        : value;
+        }
 
-    return finalHeaders;
+        return finalHeaders;
 }

--- a/src/files/firebase-to-svelte-kit.js
+++ b/src/files/firebase-to-svelte-kit.js
@@ -5,16 +5,16 @@
  * @return {import('@sveltejs/kit').IncomingRequest}
  */
 export function toSvelteKitRequest(request) {
-	const host = `${request.headers['x-forwarded-proto']}://${request.headers.host}`;
-	const {href, pathname, searchParams: searchParameters} = new URL(request.url || '', host);
+    const host = `${request.headers['x-forwarded-proto']}://${request.headers.host}`;
+    const { href, pathname, searchParams: searchParameters } = new URL(request.url || '', host);
 
-	return new Request(href, {
-		method: request.method,
-		headers: toSvelteKitHeaders(request.headers),
-		body: request.rawBody
-			? request.rawBody
-			: null,
-	});
+    return new Request(href, {
+        method: request.method,
+        headers: toSvelteKitHeaders(request.headers),
+        body: request.rawBody
+            ? request.rawBody
+            : null,
+    });
 }
 
 /**
@@ -30,15 +30,15 @@ export function toSvelteKitRequest(request) {
  * @returns {Record<string, string>}
  */
 export function toSvelteKitHeaders(headers) {
-	/** @type {Record<string, string>} */
-	const finalHeaders = {};
+    /** @type {Record<string, string>} */
+    const finalHeaders = {};
 
-	// Assume string | string[] types for all values
-	for (const [key, value] of Object.entries(headers)) {
-		finalHeaders[key] = Array.isArray(value)
-			? value.join(',')
-			: value;
-	}
+    // Assume string | string[] types for all values
+    for (const [key, value] of Object.entries(headers)) {
+        finalHeaders[key] = Array.isArray(value)
+            ? value.join(',')
+            : value;
+    }
 
-	return finalHeaders;
+    return finalHeaders;
 }

--- a/src/files/firebase-to-svelte-kit.js
+++ b/src/files/firebase-to-svelte-kit.js
@@ -5,16 +5,16 @@
  * @return {import('@sveltejs/kit').IncomingRequest}
  */
 export function toSvelteKitRequest(request) {
-        const host = `${request.headers['x-forwarded-proto']}://${request.headers.host}`;
-        const { href, pathname, searchParams: searchParameters } = new URL(request.url || '', host);
+	const host = `${request.headers['x-forwarded-proto']}://${request.headers.host}`;
+	const { href, pathname, searchParams: searchParameters } = new URL(request.url || '', host);
 
-        return new Request(href, {
-                method: request.method,
-                headers: toSvelteKitHeaders(request.headers),
-                body: request.rawBody
-                        ? request.rawBody
-                        : null,
-        });
+	return new Request(href, {
+		method: request.method,
+		headers: toSvelteKitHeaders(request.headers),
+		body: request.rawBody
+			? request.rawBody
+			: null,
+	});
 }
 
 /**
@@ -30,15 +30,15 @@ export function toSvelteKitRequest(request) {
  * @returns {Record<string, string>}
  */
 export function toSvelteKitHeaders(headers) {
-        /** @type {Record<string, string>} */
-        const finalHeaders = {};
+	/** @type {Record<string, string>} */
+	const finalHeaders = {};
 
-        // Assume string | string[] types for all values
-        for (const [key, value] of Object.entries(headers)) {
-                finalHeaders[key] = Array.isArray(value)
-                        ? value.join(',')
-                        : value;
-        }
+	// Assume string | string[] types for all values
+	for (const [key, value] of Object.entries(headers)) {
+		finalHeaders[key] = Array.isArray(value)
+			? value.join(',')
+			: value;
+	}
 
-        return finalHeaders;
+	return finalHeaders;
 }

--- a/src/files/shims.js
+++ b/src/files/shims.js
@@ -1,2 +1,2 @@
-// @ts-expect-error
-export {fetch, Response, Request, Headers} from '@sveltejs/kit/install-fetch';
+import { installFetch } from '@sveltejs/kit/install-fetch';
+installFetch();

--- a/src/index.js
+++ b/src/index.js
@@ -4,84 +4,85 @@ import process from 'process';
 import { fileURLToPath } from 'url';
 import esbuild from 'esbuild';
 import {
-  ensureCompatibleCloudFunctionVersion,
-  ensureStaticResourceDirsDiffer,
-  logRelativeDir,
-  parseFirebaseConfiguration,
+    ensureCompatibleCloudFunctionVersion,
+    ensureStaticResourceDirsDiffer,
+    logRelativeDir,
+    parseFirebaseConfiguration,
 } from './utils.js';
 
 /** @type {import('.')} **/
 const entrypoint = function (options = {}) {
-  return {
-    name: 'svelte-adapter-firebase',
-    async adapt(builder) {
-      const {
-        esbuildOptions = undefined,
-        firebaseJsonPath = 'firebase.json',
-        target = undefined,
-        sourceRewriteMatch = '**',
-      } = options;
+    return {
+        name: 'svelte-adapter-firebase',
+        async adapt(builder) {
+            const {
+                esbuildOptions = undefined,
+                firebaseJsonPath = 'firebase.json',
+                target = undefined,
+                sourceRewriteMatch = '**',
+            } = options;
 
-      builder.log.minor(`Adapter configuration:\n\t${JSON.stringify(options)}`);
-      const { functions, publicDir } = parseFirebaseConfiguration({ firebaseJsonPath, target, sourceRewriteMatch });
-      ensureStaticResourceDirsDiffer({ source: path.join(process.cwd(), builder.getStaticDirectory()), dest: publicDir });
+            builder.log.minor(`Adapter configuration:\n\t${JSON.stringify(options)}`);
+            const { functions, publicDir } = parseFirebaseConfiguration({ firebaseJsonPath, target, sourceRewriteMatch });
+            ensureStaticResourceDirsDiffer({ source: path.join(process.cwd(), builder.getStaticDirectory()), dest: publicDir });
 
-      const functionsPackageJson = JSON.parse(readFileSync(path.join(functions.source, 'package.json'), 'utf-8'));
-      if (!functionsPackageJson?.main) {
-        throw new Error(`Error reading ${functionsPackageJson}. Required field "main" missing.`);
-      }
+            const functionsPackageJson = JSON.parse(readFileSync(path.join(functions.source, 'package.json'), 'utf-8'));
+            if (!functionsPackageJson?.main) {
+                throw new Error(`Error reading ${functionsPackageJson}. Required field "main" missing.`);
+            }
 
-      const dirs = {
-        files: fileURLToPath(new URL('./files', import.meta.url)),
-        serverDirname: functions.name ?? 'svelteKit',
-        serverPath: path.join(functions.source, path.dirname(functionsPackageJson.main), functions.name ?? 'svelteKit'),
-        tmp: path.join('.svelte-kit', 'firebase'),
-      };
-      const ssrFunc = {
-        entrypoint: path.join(functions.source, functionsPackageJson.main),
-        svelteSSR: dirs.serverDirname.replace(/\W/g, '') + 'Server',
-      };
+            const dirs = {
+                files: fileURLToPath(new URL('./files', import.meta.url)),
+                serverDirname: functions.name ?? 'svelteKit',
+                serverPath: path.join(functions.source, path.dirname(functionsPackageJson.main), functions.name ?? 'svelteKit'),
+                tmp: path.join('.svelte-kit', 'firebase'),
+            };
+            const ssrFunc = {
+                entrypoint: path.join(functions.source, functionsPackageJson.main),
+                svelteSSR: dirs.serverDirname.replace(/\W/g, '') + 'Server',
+            };
 
-      const relativePath = path.posix.relative(dirs.tmp, builder.getServerDirectory());
-      const runtimeVersion = ensureCompatibleCloudFunctionVersion({
-        functionsPackageJsonEngine: functionsPackageJson?.engines?.node,
-        firebaseJsonFunctionsRuntime: functions.runtime,
-      });
-      builder.rimraf(dirs.tmp);
-      builder.rimraf(dirs.serverPath);
-      builder.copy(
-        path.join(dirs.files, 'entry.js')
-        , path.join(dirs.tmp, 'entry.js'), {
-           replace: { SERVER: `${relativePath}/index.js`, MANIFEST: `./manifest.js` } });
-      builder.copy(path.join(dirs.files, 'firebase-to-svelte-kit.js'), path.join(dirs.tmp, 'firebase-to-svelte-kit.js'));
-      
-      writeFileSync(
-				`${dirs.tmp}/manifest.js`,
-				`export const manifest = ${builder.generateManifest({
-					relativePath
-				})};\n`
-			);
+            const relativePath = path.posix.relative(dirs.tmp, builder.getServerDirectory());
+            const runtimeVersion = ensureCompatibleCloudFunctionVersion({
+                functionsPackageJsonEngine: functionsPackageJson?.engines?.node,
+                firebaseJsonFunctionsRuntime: functions.runtime,
+            });
+            builder.rimraf(dirs.tmp);
+            builder.rimraf(dirs.serverPath);
+            builder.copy(
+                path.join(dirs.files, 'entry.js')
+                , path.join(dirs.tmp, 'entry.js'), {
+                replace: { SERVER: `${relativePath}/index.js`, MANIFEST: `./manifest.js` }
+            });
+            builder.copy(path.join(dirs.files, 'firebase-to-svelte-kit.js'), path.join(dirs.tmp, 'firebase-to-svelte-kit.js'));
 
-      /** @type {esbuild.BuildOptions} */
-      const defaultOptions = {
-        entryPoints: [path.join(dirs.tmp, 'entry.js')],
-        outfile: path.join(dirs.serverPath, 'index.js'),
-        bundle: true,
-        inject: [path.join(dirs.files, 'shims.js')],
-        platform: 'node',
-        target: `node${runtimeVersion}`,
-      };
+            writeFileSync(
+                `${dirs.tmp}/manifest.js`,
+                `export const manifest = ${builder.generateManifest({
+                    relativePath
+                })};\n`
+            );
 
-      const buildOptions = esbuildOptions
-        ? await esbuildOptions(defaultOptions)
-        : defaultOptions;
-      await esbuild.build(buildOptions);
-      builder.log.minor(logRelativeDir('Writing Cloud Function server assets to', dirs.serverPath));
+            /** @type {esbuild.BuildOptions} */
+            const defaultOptions = {
+                entryPoints: [path.join(dirs.tmp, 'entry.js')],
+                outfile: path.join(dirs.serverPath, 'index.js'),
+                bundle: true,
+                inject: [path.join(dirs.files, 'shims.js')],
+                platform: 'node',
+                target: `node${runtimeVersion}`,
+            };
 
-      try {
-        if (!readFileSync(ssrFunc.entrypoint, 'utf-8').includes(`${functions.name} =`)) {
-          builder.log.warn(`Add the following Cloud Function to ${ssrFunc.entrypoint}`);
-                        builder.log.warn(`
+            const buildOptions = esbuildOptions
+                ? await esbuildOptions(defaultOptions)
+                : defaultOptions;
+            await esbuild.build(buildOptions);
+            builder.log.minor(logRelativeDir('Writing Cloud Function server assets to', dirs.serverPath));
+
+            try {
+                if (!readFileSync(ssrFunc.entrypoint, 'utf-8').includes(`${functions.name} =`)) {
+                    builder.log.warn(`Add the following Cloud Function to ${ssrFunc.entrypoint}`);
+                    builder.log.warn(`
               let ${ssrFunc.svelteSSR};
               exports.${functions.name} = functions.region("us-central1").https.onRequest(async (request, response) => {
                 if (!${ssrFunc.svelteSSR}) {
@@ -93,21 +94,21 @@ const entrypoint = function (options = {}) {
                 return ${ssrFunc.svelteSSR}(request, response);
               });
                   `);
-        }
-      } catch (error) {
-        throw new Error(`Error reading Cloud Function entrypoint file: ${ssrFunc.entrypoint}. ${error.message}`);
-      }
+                }
+            } catch (error) {
+                throw new Error(`Error reading Cloud Function entrypoint file: ${ssrFunc.entrypoint}. ${error.message}`);
+            }
 
-      builder.log.minor(logRelativeDir('Erasing destination static asset dir before processing', publicDir));
-      builder.rimraf(publicDir);
+            builder.log.minor(logRelativeDir('Erasing destination static asset dir before processing', publicDir));
+            builder.rimraf(publicDir);
 
-      builder.log.minor(logRelativeDir('Writing client application to', publicDir));
-      builder.writeStatic(publicDir);
-      builder.writeClient(publicDir);
+            builder.log.minor(logRelativeDir('Writing client application to', publicDir));
+            builder.writeStatic(publicDir);
+            builder.writeClient(publicDir);
 
-      builder.log.minor(logRelativeDir('Prerendering static pages to', publicDir));
-    },
-  };
+            builder.log.minor(logRelativeDir('Prerendering static pages to', publicDir));
+        },
+    };
 };
 
 export default entrypoint;

--- a/src/index.js
+++ b/src/index.js
@@ -4,85 +4,85 @@ import process from 'process';
 import { fileURLToPath } from 'url';
 import esbuild from 'esbuild';
 import {
-    ensureCompatibleCloudFunctionVersion,
-    ensureStaticResourceDirsDiffer,
-    logRelativeDir,
-    parseFirebaseConfiguration,
+        ensureCompatibleCloudFunctionVersion,
+        ensureStaticResourceDirsDiffer,
+        logRelativeDir,
+        parseFirebaseConfiguration,
 } from './utils.js';
 
 /** @type {import('.')} **/
 const entrypoint = function (options = {}) {
-    return {
-        name: 'svelte-adapter-firebase',
-        async adapt(builder) {
-            const {
-                esbuildOptions = undefined,
-                firebaseJsonPath = 'firebase.json',
-                target = undefined,
-                sourceRewriteMatch = '**',
-            } = options;
+        return {
+                name: 'svelte-adapter-firebase',
+                async adapt(builder) {
+                        const {
+                                esbuildOptions = undefined,
+                                firebaseJsonPath = 'firebase.json',
+                                target = undefined,
+                                sourceRewriteMatch = '**',
+                        } = options;
 
-            builder.log.minor(`Adapter configuration:\n\t${JSON.stringify(options)}`);
-            const { functions, publicDir } = parseFirebaseConfiguration({ firebaseJsonPath, target, sourceRewriteMatch });
-            ensureStaticResourceDirsDiffer({ source: path.join(process.cwd(), builder.getStaticDirectory()), dest: publicDir });
+                        builder.log.minor(`Adapter configuration:\n\t${JSON.stringify(options)}`);
+                        const { functions, publicDir } = parseFirebaseConfiguration({ firebaseJsonPath, target, sourceRewriteMatch });
+                        ensureStaticResourceDirsDiffer({ source: path.join(process.cwd(), builder.getStaticDirectory()), dest: publicDir });
 
-            const functionsPackageJson = JSON.parse(readFileSync(path.join(functions.source, 'package.json'), 'utf-8'));
-            if (!functionsPackageJson?.main) {
-                throw new Error(`Error reading ${functionsPackageJson}. Required field "main" missing.`);
-            }
+                        const functionsPackageJson = JSON.parse(readFileSync(path.join(functions.source, 'package.json'), 'utf-8'));
+                        if (!functionsPackageJson?.main) {
+                                throw new Error(`Error reading ${functionsPackageJson}. Required field "main" missing.`);
+                        }
 
-            const dirs = {
-                files: fileURLToPath(new URL('./files', import.meta.url)),
-                serverDirname: functions.name ?? 'svelteKit',
-                serverPath: path.join(functions.source, path.dirname(functionsPackageJson.main), functions.name ?? 'svelteKit'),
-                tmp: path.join('.svelte-kit', 'firebase'),
-            };
-            const ssrFunc = {
-                entrypoint: path.join(functions.source, functionsPackageJson.main),
-                svelteSSR: dirs.serverDirname.replace(/\W/g, '') + 'Server',
-            };
+                        const dirs = {
+                                files: fileURLToPath(new URL('./files', import.meta.url)),
+                                serverDirname: functions.name ?? 'svelteKit',
+                                serverPath: path.join(functions.source, path.dirname(functionsPackageJson.main), functions.name ?? 'svelteKit'),
+                                tmp: path.join('.svelte-kit', 'firebase'),
+                        };
+                        const ssrFunc = {
+                                entrypoint: path.join(functions.source, functionsPackageJson.main),
+                                svelteSSR: dirs.serverDirname.replace(/\W/g, '') + 'Server',
+                        };
 
-            const relativePath = path.posix.relative(dirs.tmp, builder.getServerDirectory());
-            const runtimeVersion = ensureCompatibleCloudFunctionVersion({
-                functionsPackageJsonEngine: functionsPackageJson?.engines?.node,
-                firebaseJsonFunctionsRuntime: functions.runtime,
-            });
-            builder.rimraf(dirs.tmp);
-            builder.rimraf(dirs.serverPath);
-            builder.copy(
-                path.join(dirs.files, 'entry.js')
-                , path.join(dirs.tmp, 'entry.js'), {
-                replace: { SERVER: `${relativePath}/index.js`, MANIFEST: `./manifest.js` }
-            });
-            builder.copy(path.join(dirs.files, 'firebase-to-svelte-kit.js'), path.join(dirs.tmp, 'firebase-to-svelte-kit.js'));
+                        const relativePath = path.posix.relative(dirs.tmp, builder.getServerDirectory());
+                        const runtimeVersion = ensureCompatibleCloudFunctionVersion({
+                                functionsPackageJsonEngine: functionsPackageJson?.engines?.node,
+                                firebaseJsonFunctionsRuntime: functions.runtime,
+                        });
+                        builder.rimraf(dirs.tmp);
+                        builder.rimraf(dirs.serverPath);
+                        builder.copy(
+                                path.join(dirs.files, 'entry.js')
+                                , path.join(dirs.tmp, 'entry.js'), {
+                                replace: { SERVER: `${relativePath}/index.js`, MANIFEST: `./manifest.js` }
+                        });
+                        builder.copy(path.join(dirs.files, 'firebase-to-svelte-kit.js'), path.join(dirs.tmp, 'firebase-to-svelte-kit.js'));
 
-            writeFileSync(
-                `${dirs.tmp}/manifest.js`,
-                `export const manifest = ${builder.generateManifest({
-                    relativePath
-                })};\n`
-            );
+                        writeFileSync(
+                                `${dirs.tmp}/manifest.js`,
+                                `export const manifest = ${builder.generateManifest({
+                                        relativePath
+                                })};\n`
+                        );
 
-            /** @type {esbuild.BuildOptions} */
-            const defaultOptions = {
-                entryPoints: [path.join(dirs.tmp, 'entry.js')],
-                outfile: path.join(dirs.serverPath, 'index.js'),
-                bundle: true,
-                inject: [path.join(dirs.files, 'shims.js')],
-                platform: 'node',
-                target: `node${runtimeVersion}`,
-            };
+                        /** @type {esbuild.BuildOptions} */
+                        const defaultOptions = {
+                                entryPoints: [path.join(dirs.tmp, 'entry.js')],
+                                outfile: path.join(dirs.serverPath, 'index.js'),
+                                bundle: true,
+                                inject: [path.join(dirs.files, 'shims.js')],
+                                platform: 'node',
+                                target: `node${runtimeVersion}`,
+                        };
 
-            const buildOptions = esbuildOptions
-                ? await esbuildOptions(defaultOptions)
-                : defaultOptions;
-            await esbuild.build(buildOptions);
-            builder.log.minor(logRelativeDir('Writing Cloud Function server assets to', dirs.serverPath));
+                        const buildOptions = esbuildOptions
+                                ? await esbuildOptions(defaultOptions)
+                                : defaultOptions;
+                        await esbuild.build(buildOptions);
+                        builder.log.minor(logRelativeDir('Writing Cloud Function server assets to', dirs.serverPath));
 
-            try {
-                if (!readFileSync(ssrFunc.entrypoint, 'utf-8').includes(`${functions.name} =`)) {
-                    builder.log.warn(`Add the following Cloud Function to ${ssrFunc.entrypoint}`);
-                    builder.log.warn(`
+                        try {
+                                if (!readFileSync(ssrFunc.entrypoint, 'utf-8').includes(`${functions.name} =`)) {
+                                        builder.log.warn(`Add the following Cloud Function to ${ssrFunc.entrypoint}`);
+                                        builder.log.warn(`
               let ${ssrFunc.svelteSSR};
               exports.${functions.name} = functions.region("us-central1").https.onRequest(async (request, response) => {
                 if (!${ssrFunc.svelteSSR}) {
@@ -94,21 +94,21 @@ const entrypoint = function (options = {}) {
                 return ${ssrFunc.svelteSSR}(request, response);
               });
                   `);
-                }
-            } catch (error) {
-                throw new Error(`Error reading Cloud Function entrypoint file: ${ssrFunc.entrypoint}. ${error.message}`);
-            }
+                                }
+                        } catch (error) {
+                                throw new Error(`Error reading Cloud Function entrypoint file: ${ssrFunc.entrypoint}. ${error.message}`);
+                        }
 
-            builder.log.minor(logRelativeDir('Erasing destination static asset dir before processing', publicDir));
-            builder.rimraf(publicDir);
+                        builder.log.minor(logRelativeDir('Erasing destination static asset dir before processing', publicDir));
+                        builder.rimraf(publicDir);
 
-            builder.log.minor(logRelativeDir('Writing client application to', publicDir));
-            builder.writeStatic(publicDir);
-            builder.writeClient(publicDir);
+                        builder.log.minor(logRelativeDir('Writing client application to', publicDir));
+                        builder.writeStatic(publicDir);
+                        builder.writeClient(publicDir);
 
-            builder.log.minor(logRelativeDir('Prerendering static pages to', publicDir));
-        },
-    };
+                        builder.log.minor(logRelativeDir('Prerendering static pages to', publicDir));
+                },
+        };
 };
 
 export default entrypoint;

--- a/src/index.js
+++ b/src/index.js
@@ -1,103 +1,113 @@
-import {readFileSync} from 'fs';
+import { readFileSync, writeFileSync } from 'fs';
 import path from 'path';
 import process from 'process';
-import {fileURLToPath} from 'url';
+import { fileURLToPath } from 'url';
 import esbuild from 'esbuild';
 import {
-	ensureCompatibleCloudFunctionVersion,
-	ensureStaticResourceDirsDiffer,
-	logRelativeDir,
-	parseFirebaseConfiguration,
+  ensureCompatibleCloudFunctionVersion,
+  ensureStaticResourceDirsDiffer,
+  logRelativeDir,
+  parseFirebaseConfiguration,
 } from './utils.js';
 
 /** @type {import('.')} **/
 const entrypoint = function (options = {}) {
-	return {
-		name: 'svelte-adapter-firebase',
-		async adapt({utils, config}) {
-			const {
-				esbuildOptions = undefined,
-				firebaseJsonPath = 'firebase.json',
-				target = undefined,
-				sourceRewriteMatch = '**',
-			} = options;
+  return {
+    name: 'svelte-adapter-firebase',
+    async adapt(builder) {
+      const {
+        esbuildOptions = undefined,
+        firebaseJsonPath = 'firebase.json',
+        target = undefined,
+        sourceRewriteMatch = '**',
+      } = options;
 
-			utils.log.minor(`Adapter configuration:\n\t${JSON.stringify(options)}`);
-			const {functions, publicDir} = parseFirebaseConfiguration({firebaseJsonPath, target, sourceRewriteMatch});
-			ensureStaticResourceDirsDiffer({source: path.join(process.cwd(), config.kit.files.assets), dest: publicDir});
+      builder.log.minor(`Adapter configuration:\n\t${JSON.stringify(options)}`);
+      const { functions, publicDir } = parseFirebaseConfiguration({ firebaseJsonPath, target, sourceRewriteMatch });
+      ensureStaticResourceDirsDiffer({ source: path.join(process.cwd(), builder.getStaticDirectory()), dest: publicDir });
 
-			const functionsPackageJson = JSON.parse(readFileSync(path.join(functions.source, 'package.json'), 'utf-8'));
-			if (!functionsPackageJson?.main) {
-				throw new Error(`Error reading ${functionsPackageJson}. Required field "main" missing.`);
-			}
+      const functionsPackageJson = JSON.parse(readFileSync(path.join(functions.source, 'package.json'), 'utf-8'));
+      if (!functionsPackageJson?.main) {
+        throw new Error(`Error reading ${functionsPackageJson}. Required field "main" missing.`);
+      }
 
-			const dirs = {
-				files: fileURLToPath(new URL('./files', import.meta.url)),
-				serverDirname: functions.name ?? 'svelteKit',
-				serverPath: path.join(functions.source, path.dirname(functionsPackageJson.main), functions.name ?? 'svelteKit'),
-				tmp: path.join('.svelte-kit', 'firebase'),
-			};
-			const ssrFunc = {
-				entrypoint: path.join(functions.source, functionsPackageJson.main),
-				svelteSSR: dirs.serverDirname.replace(/\W/g, '') + 'Server',
-			};
+      const dirs = {
+        files: fileURLToPath(new URL('./files', import.meta.url)),
+        serverDirname: functions.name ?? 'svelteKit',
+        serverPath: path.join(functions.source, path.dirname(functionsPackageJson.main), functions.name ?? 'svelteKit'),
+        tmp: path.join('.svelte-kit', 'firebase'),
+      };
+      const ssrFunc = {
+        entrypoint: path.join(functions.source, functionsPackageJson.main),
+        svelteSSR: dirs.serverDirname.replace(/\W/g, '') + 'Server',
+      };
 
-			const runtimeVersion = ensureCompatibleCloudFunctionVersion({
-				functionsPackageJsonEngine: functionsPackageJson?.engines?.node,
-				firebaseJsonFunctionsRuntime: functions.runtime,
-			});
-			utils.rimraf(dirs.tmp);
-			utils.rimraf(dirs.serverPath);
-			utils.copy(path.join(dirs.files, 'entry.js'), path.join(dirs.tmp, 'entry.js'));
-			utils.copy(path.join(dirs.files, 'firebase-to-svelte-kit.js'), path.join(dirs.tmp, 'firebase-to-svelte-kit.js'));
+      const relativePath = path.posix.relative(dirs.tmp, builder.getServerDirectory());
+      const runtimeVersion = ensureCompatibleCloudFunctionVersion({
+        functionsPackageJsonEngine: functionsPackageJson?.engines?.node,
+        firebaseJsonFunctionsRuntime: functions.runtime,
+      });
+      builder.rimraf(dirs.tmp);
+      builder.rimraf(dirs.serverPath);
+      builder.copy(
+        path.join(dirs.files, 'entry.js')
+        , path.join(dirs.tmp, 'entry.js'), {
+           replace: { SERVER: `${relativePath}/index.js`, MANIFEST: `./manifest.js` } });
+      builder.copy(path.join(dirs.files, 'firebase-to-svelte-kit.js'), path.join(dirs.tmp, 'firebase-to-svelte-kit.js'));
+      
+      writeFileSync(
+				`${dirs.tmp}/manifest.js`,
+				`export const manifest = ${builder.generateManifest({
+					relativePath
+				})};\n`
+			);
 
-			/** @type {esbuild.BuildOptions} */
-			const defaultOptions = {
-				entryPoints: [path.join(dirs.tmp, 'entry.js')],
-				outfile: path.join(dirs.serverPath, 'index.js'),
-				bundle: true,
-				inject: [path.join(dirs.files, 'shims.js')],
-				platform: 'node',
-				target: `node${runtimeVersion}`,
-			};
+      /** @type {esbuild.BuildOptions} */
+      const defaultOptions = {
+        entryPoints: [path.join(dirs.tmp, 'entry.js')],
+        outfile: path.join(dirs.serverPath, 'index.js'),
+        bundle: true,
+        inject: [path.join(dirs.files, 'shims.js')],
+        platform: 'node',
+        target: `node${runtimeVersion}`,
+      };
 
-			const buildOptions = esbuildOptions
-				? await esbuildOptions(defaultOptions)
-				: defaultOptions;
-			await esbuild.build(buildOptions);
-			utils.log.minor(logRelativeDir('Writing Cloud Function server assets to', dirs.serverPath));
+      const buildOptions = esbuildOptions
+        ? await esbuildOptions(defaultOptions)
+        : defaultOptions;
+      await esbuild.build(buildOptions);
+      builder.log.minor(logRelativeDir('Writing Cloud Function server assets to', dirs.serverPath));
 
-			try {
-				if (!readFileSync(ssrFunc.entrypoint, 'utf-8').includes(`${functions.name} =`)) {
-					utils.log.warn(`Add the following Cloud Function to ${ssrFunc.entrypoint}`);
-					utils.log.warn(`
-let ${ssrFunc.svelteSSR};
-exports.${functions.name} = functions.region("us-central1").https.onRequest(async (request, response) => {
-	if (!${ssrFunc.svelteSSR}) {
-		functions.logger.info("Initialising SvelteKit SSR entry");
-		${ssrFunc.svelteSSR} = require("./${dirs.serverDirname}/index").default;
-		functions.logger.info("SvelteKit SSR entry initialised!");
-	}
-	functions.logger.info("Requested resource: " + request.originalUrl);
-	return ${ssrFunc.svelteSSR}(request, response);
-});
-		`);
-				}
-			} catch (error) {
-				throw new Error(`Error reading Cloud Function entrypoint file: ${ssrFunc.entrypoint}. ${error.message}`);
-			}
+      try {
+        if (!readFileSync(ssrFunc.entrypoint, 'utf-8').includes(`${functions.name} =`)) {
+          builder.log.warn(`Add the following Cloud Function to ${ssrFunc.entrypoint}`);
+                        builder.log.warn(`
+              let ${ssrFunc.svelteSSR};
+              exports.${functions.name} = functions.region("us-central1").https.onRequest(async (request, response) => {
+                if (!${ssrFunc.svelteSSR}) {
+                  functions.logger.info("Initialising SvelteKit SSR entry");
+                  ${ssrFunc.svelteSSR} = require("./${dirs.serverDirname}/index").default;
+                  functions.logger.info("SvelteKit SSR entry initialised!");
+                }
+                functions.logger.info("Requested resource: " + request.originalUrl);
+                return ${ssrFunc.svelteSSR}(request, response);
+              });
+                  `);
+        }
+      } catch (error) {
+        throw new Error(`Error reading Cloud Function entrypoint file: ${ssrFunc.entrypoint}. ${error.message}`);
+      }
 
-			utils.log.minor(logRelativeDir('Erasing destination static asset dir before processing', publicDir));
-			utils.rimraf(publicDir);
+      builder.log.minor(logRelativeDir('Erasing destination static asset dir before processing', publicDir));
+      builder.rimraf(publicDir);
 
-			utils.log.minor(logRelativeDir('Writing client application to', publicDir));
-			utils.copy_static_files(publicDir);
-			utils.copy_client_files(publicDir);
+      builder.log.minor(logRelativeDir('Writing client application to', publicDir));
+      builder.writeStatic(publicDir);
+      builder.writeClient(publicDir);
 
-			utils.log.minor(logRelativeDir('Prerendering static pages to', publicDir));
-			await utils.prerender({dest: publicDir});
-		},
-	};
+      builder.log.minor(logRelativeDir('Prerendering static pages to', publicDir));
+    },
+  };
 };
 
 export default entrypoint;


### PR DESCRIPTION
# Summary

Update Adapter to support the latest version (next@303) of SvelteKit. 

Fixes: #153

No support for fancy features like route splitting.

Tested deployment on a live site with Firebase

## Other Information
Took some code from the other PR #157 so the author deserves credit.

## Implementation details
- Uses Server instead of App
- Use the generated manifest of the builder instead of SvelteKit
- New way of using installFetch
- Remove the deprecated prerender call
- Thought process in long live video on [YouTube](https://www.youtube.com/watch?v=AhOWnouyfhE)


