### PR TITLE
fix: any response headers from SvelteKit are not passed to express on Node.js v16 runtime

### DIFF
--- a/src/files/entry.js
+++ b/src/files/entry.js
@@ -20,6 +20,6 @@ export default async function svelteKit(request, response) {
 	const body = await rendered.text();
 
 	return rendered
-		? response.writeHead(rendered.status, rendered.headers).end(body)
+		? response.writeHead(rendered.status, rendered.headers ? [...rendered.headers] : []).end(body)
 		: response.writeHead(404, 'Not Found').end();
 }


### PR DESCRIPTION
# Summary

changed to pass headers value as an Array of headers to `express.Response#writeHead(...)`

Fixes: https://github.com/jthegedus/svelte-adapter-firebase/issues/165