### PR TITLE
fix: Pass rendered.headers to writeHead as object

### DIFF
--- a/src/files/entry.js
+++ b/src/files/entry.js
@@ -20,6 +20,6 @@ export default async function svelteKit(request, response) {
 	const body = await rendered.text();
 
 	return rendered
-		? response.writeHead(rendered.status, rendered.headers).end(body)
+		? response.writeHead(rendered.status, Object.fromEntries(rendered.headers)).end(body)
 		: response.writeHead(404, 'Not Found').end();
 }

--- a/src/index.js
+++ b/src/index.js
@@ -95,7 +95,6 @@ const entrypoint = function (options = {}) {
 			builder.rimraf(publicDir);
 
 			builder.log.minor(logRelativeDir('Writing client application to', publicDir));
-			builder.writeStatic(publicDir);
 			builder.writeClient(publicDir);
 
 			builder.log.minor(logRelativeDir('Prerendering static pages to', publicDir));


### PR DESCRIPTION
# Summary

Fixes headers not being passed from SvelteKit response object to Express Response object.

Fixes: #165

# Other Information

In order for the tests to successfully finish #173  has to be merged into main or this branch first.