### PR TITLE
fix(#180): Prepend `Server.init` before calling `Server.respond`

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,19 +30,19 @@ jobs:
         params:
           - {
               test_dir: "functions_single_site",
-              validation_app_dir: "public/_app/immutable/pages/index.svelte-*.js",
+              validation_app_dir: "public/_app/immutable/components/pages/_page.svelte-*.js",
               validation_compute_dir: "functions/sveltekit/index.js",
               nested_dir: ".",
             }
           - {
               test_dir: "nested_app_dirs",
-              validation_app_dir: "public/_app/immutable/pages/index.svelte-*.js",
+              validation_app_dir: "public/_app/immutable/components/pages/_page.svelte-*.js",
               validation_compute_dir: "functions/sveltekit/index.js",
               nested_dir: "app",
             }
           - {
               test_dir: "run_service_id",
-              validation_app_dir: "public/_app/immutable/pages/index.svelte-*.js",
+              validation_app_dir: "public/_app/immutable/components/pages/_page.svelte-*.js",
               validation_compute_dir: "functions/cloudrun/index.js",
               nested_dir: ".",
             }

--- a/package.json
+++ b/package.json
@@ -41,10 +41,10 @@
     "esbuild": "^0.15.2"
   },
   "peerDependencies": {
-    "@sveltejs/kit": "^1.0.0-next.405"
+    "@sveltejs/kit": "^1.0.0-next.443"
   },
   "devDependencies": {
-    "@sveltejs/kit": "^1.0.0-next.405",
+    "@sveltejs/kit": "^1.0.0-next.443",
     "@types/express": "^4.17.13",
     "@types/node": "^18.7.3",
     "ava": "^4.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 lockfileVersion: 5.4
 
 specifiers:
-  '@sveltejs/kit': ^1.0.0-next.405
+  '@sveltejs/kit': ^1.0.0-next.443
   '@types/express': ^4.17.13
   '@types/node': ^18.7.3
   ava: ^4.3.1
@@ -13,7 +13,7 @@ dependencies:
   esbuild: 0.15.2
 
 devDependencies:
-  '@sveltejs/kit': 1.0.0-next.405_svelte@3.49.0+vite@3.0.7
+  '@sveltejs/kit': 1.0.0-next.444_svelte@3.49.0+vite@3.0.7
   '@types/express': 4.17.13
   '@types/node': 18.7.3
   ava: 4.3.1
@@ -333,6 +333,10 @@ packages:
     engines: {node: '>=10.13.0'}
     dev: true
 
+  /@polka/url/1.0.0-next.21:
+    resolution: {integrity: sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==}
+    dev: true
+
   /@protobufjs/aspromise/1.1.2:
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
     dev: true
@@ -394,8 +398,8 @@ packages:
       picomatch: 2.3.1
     dev: true
 
-  /@sveltejs/kit/1.0.0-next.405_svelte@3.49.0+vite@3.0.7:
-    resolution: {integrity: sha512-jHSa74F7k+hC+0fof75g/xm/+1M5sM66Qt6v8eLLMSgjkp36Lb5xOioBhbl6w0NYoE5xysLsBWuu+yHytfvCBA==}
+  /@sveltejs/kit/1.0.0-next.444_svelte@3.49.0+vite@3.0.7:
+    resolution: {integrity: sha512-B9ekUK5r/3IODxyXjAmEWFC1ytxRlsnApgF8qV/2IJWvWXvj62PjB8qK7UBvMM9A1codfx94RMvj9r6wTKRIAA==}
     engines: {node: '>=16.9'}
     hasBin: true
     requiresBuild: true
@@ -404,10 +408,18 @@ packages:
       vite: ^3.0.0
     dependencies:
       '@sveltejs/vite-plugin-svelte': 1.0.1_svelte@3.49.0+vite@3.0.7
-      chokidar: 3.5.3
+      cookie: 0.5.0
+      devalue: 2.0.1
+      kleur: 4.1.5
+      magic-string: 0.26.2
+      mime: 3.0.0
+      node-fetch: 3.2.10
       sade: 1.8.1
+      set-cookie-parser: 2.5.1
+      sirv: 2.0.2
       svelte: 3.49.0
       tiny-glob: 0.2.9
+      undici: 5.10.0
       vite: 3.0.7
     transitivePeerDependencies:
       - diff-match-patch
@@ -1433,6 +1445,11 @@ packages:
       array-find-index: 1.0.2
     dev: true
 
+  /data-uri-to-buffer/4.0.0:
+    resolution: {integrity: sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==}
+    engines: {node: '>= 12'}
+    dev: true
+
   /date-time/3.1.0:
     resolution: {integrity: sha512-uqCUKXE5q1PNBXjPqvwhwJf9SwMoAHBgWJ6DcrnS5o+W2JOiIILl0JEdVD8SGujrNS02GGxgwAg2PN2zONgtjg==}
     engines: {node: '>=6'}
@@ -1541,6 +1558,10 @@ packages:
   /destroy/1.2.0:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+    dev: true
+
+  /devalue/2.0.1:
+    resolution: {integrity: sha512-I2TiqT5iWBEyB8GRfTDP0hiLZ0YeDJZ+upDxjBfOC2lebO5LezQMv7QvIUTzdb64jQyAKLf1AHADtGN+jw6v8Q==}
     dev: true
 
   /dir-glob/3.0.1:
@@ -2656,6 +2677,14 @@ packages:
       websocket-driver: 0.7.4
     dev: true
 
+  /fetch-blob/3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.2.1
+    dev: true
+
   /figures/4.0.1:
     resolution: {integrity: sha512-rElJwkA/xS04Vfg+CaZodpso7VqBknOYbzi6I76hI4X80RUjkSxO2oAyPmGbuXUppywjqndOrQDl817hDnI++w==}
     engines: {node: '>=12'}
@@ -2780,6 +2809,13 @@ packages:
 
   /flatted/3.2.6:
     resolution: {integrity: sha512-0sQoMh9s0BYsm+12Huy/rkKxVu4R1+r96YX5cG44rHV0pQ6iC3Q+mkoMFaGWObMFYQxCVT+ssG1ksneA2MI9KQ==}
+    dev: true
+
+  /formdata-polyfill/4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
+    dependencies:
+      fetch-blob: 3.2.0
     dev: true
 
   /forwarded/0.2.0:
@@ -3956,7 +3992,6 @@ packages:
     engines: {node: '>=10.0.0'}
     hasBin: true
     dev: true
-    optional: true
 
   /mimic-fn/2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
@@ -3997,6 +4032,11 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
+  /mrmime/1.0.1:
+    resolution: {integrity: sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==}
+    engines: {node: '>=10'}
+    dev: true
+
   /ms/2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
     dev: true
@@ -4028,6 +4068,11 @@ packages:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
     dev: true
 
+  /node-domexception/1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    dev: true
+
   /node-fetch/2.6.7:
     resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
     engines: {node: 4.x || >=6.0.0}
@@ -4038,6 +4083,15 @@ packages:
         optional: true
     dependencies:
       whatwg-url: 5.0.0
+    dev: true
+
+  /node-fetch/3.2.10:
+    resolution: {integrity: sha512-MhuzNwdURnZ1Cp4XTazr69K0BTizsBroX7Zx3UgDSVcZYKF/6p0CBe4EUb/hLqmzVhl0UpYfgRljQ4yxE+iCxA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      data-uri-to-buffer: 4.0.0
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
     dev: true
 
   /node-forge/1.3.1:
@@ -4788,6 +4842,10 @@ packages:
       - supports-color
     dev: true
 
+  /set-cookie-parser/2.5.1:
+    resolution: {integrity: sha512-1jeBGaKNGdEq4FgIrORu/N570dwoPYio8lSoYLWmX7sQ//0JY08Xh9o5pBcgmHQ/MbsYp/aZnOe1s1lIsbLprQ==}
+    dev: true
+
   /setprototypeof/1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
     dev: true
@@ -4814,6 +4872,15 @@ packages:
 
   /signal-exit/3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+    dev: true
+
+  /sirv/2.0.2:
+    resolution: {integrity: sha512-4Qog6aE29nIjAOKe/wowFTxOdmbEZKb+3tsLljaBRzJwtqto0BChD2zzH0LhgCSXiI+V7X+Y45v14wBZQ1TK3w==}
+    engines: {node: '>= 10'}
+    dependencies:
+      '@polka/url': 1.0.0-next.21
+      mrmime: 1.0.1
+      totalist: 3.0.0
     dev: true
 
   /slash/3.0.0:
@@ -5158,6 +5225,11 @@ packages:
     engines: {node: '>=0.6'}
     dev: true
 
+  /totalist/3.0.0:
+    resolution: {integrity: sha512-eM+pCBxXO/njtF7vdFsHuqb+ElbxqtI4r5EAvk6grfAFyJ6IvWlSkfZ5T9ozC6xWw3Fj1fGoSmrl0gUs46JVIw==}
+    engines: {node: '>=6'}
+    dev: true
+
   /tr46/0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
     dev: true
@@ -5264,6 +5336,11 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /undici/5.10.0:
+    resolution: {integrity: sha512-c8HsD3IbwmjjbLvoZuRI26TZic+TSEe8FPMLLOkN1AfYRhdjnKBU6yL+IwcSCbdZiX4e5t0lfMDLDCqj4Sq70g==}
+    engines: {node: '>=12.18'}
+    dev: true
+
   /unpipe/1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
@@ -5354,6 +5431,11 @@ packages:
     dependencies:
       glob-to-regexp: 0.4.1
       graceful-fs: 4.2.10
+    dev: true
+
+  /web-streams-polyfill/3.2.1:
+    resolution: {integrity: sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==}
+    engines: {node: '>= 8'}
     dev: true
 
   /webidl-conversions/3.0.1:

--- a/src/files/entry.js
+++ b/src/files/entry.js
@@ -1,3 +1,4 @@
+import process from 'process';
 import {Server} from 'SERVER';
 import {manifest} from 'MANIFEST';
 import {toSvelteKitRequest} from './firebase-to-svelte-kit.js';
@@ -16,6 +17,10 @@ const server = new Server(manifest);
  * @returns {Promise<void>}
  */
 export default async function svelteKit(request, response) {
+	await server.init({
+		env: process.env,
+	});
+
 	const rendered = await server.respond(toSvelteKitRequest(request));
 	const body = await rendered.text();
 

--- a/tests/end-to-end/test.bash
+++ b/tests/end-to-end/test.bash
@@ -5,7 +5,7 @@ set -u
 IFS=$'\n\t'
 
 # Execute end-to-end tests of the SvelteKit Todo template app built with
-# the svelte-adapter-firebase adapter hosted on the Cloud Function using 
+# the svelte-adapter-firebase adapter hosted on the Cloud Function using
 # the Firebase Emulator in CI
 #
 # Curl API and assert response payload
@@ -26,7 +26,7 @@ echo "TEST_DIR: ${TEST_DIR}"
 echo "PWD: ${PWD}"
 
 echo "${INDICATOR}Install svelte-adapter-firebase ${SCRIPT_PATH}/../../ deps"
-npm install 
+npm install
 
 echo "${INDICATOR}init SvelteKit Todos app"
 yes "" | "$(npm init svelte@next "${TEST_DIR}")"
@@ -68,24 +68,27 @@ RESULT="$(curl -L localhost:${PORT}/about)"
 
 if [[ "${RESULT}" != *"${EXPECTED_SUBSTRING}"* ]]; then
 	echo "Failed testing localhost:${PORT}/about"
+	echo -e "Expect --> ${EXPECTED_SUBSTRING}\nGot -->\n${RESULT}"
 	exit 1
 fi
 
 echo "${INDICATOR}Test GET SSR route '/'"
-EXPECTED_SUBSTRING="<h2>try editing <strong>src/routes/index.svelte</strong></h2>"
+EXPECTED_SUBSTRING="<h2>try editing <strong"
 RESULT="$(curl -L localhost:${PORT}/)"
 
 if [[ "${RESULT}" != *"${EXPECTED_SUBSTRING}"* ]]; then
 	echo "${INDICATOR}Failed testing localhost:${PORT}/"
+	echo -e "Expect --> ${EXPECTED_SUBSTRING}\nGot -->\n${RESULT}"
 	exit 1
 fi
 
 echo "${INDICATOR}Test GET SSR route '/todos'"
-EXPECTED_SUBSTRING="<h1>Todos</h1>"
+EXPECTED_SUBSTRING='<h1>Todos</h1>'
 RESULT="$(curl -L localhost:${PORT}/todos)"
 
 if [[ "${RESULT}" != *"${EXPECTED_SUBSTRING}"* ]]; then
 	echo "${INDICATOR}Failed testing localhost:${PORT}/todos/"
+	echo -e "Expect --> ${EXPECTED_SUBSTRING}\nGot -->\n${RESULT}"
 	exit 1
 fi
 
@@ -107,9 +110,9 @@ RESULT="$(curl -X POST "http://localhost:${PORT}/todos" \
 	-H "Sec-Fetch-Mode: cors" \
 	-H "Sec-Fetch-Site: same-origin" \
 	-H 'Sec-GPC: 1' --data-binary $'-----------------------------349341627025106406523834848301\r\nContent-Disposition: form-data; name="text"\r\n\r\nasdf\r\n-----------------------------349341627025106406523834848301--\r\n')"
-echo "$RESULT"
 if [[ "${RESULT}" != *"${EXPECTED_SUBSTRING}"* ]]; then
 	echo "${INDICATOR}Failed POSTing to localhost:${PORT}/todos"
+	echo -e "Expect --> ${EXPECTED_SUBSTRING}\nGot -->\n${RESULT}"
 	exit 1
 fi
 


### PR DESCRIPTION
# Summary

`hooks.js` initialization has been moved to `Server.init`. Add code to initialize hooks in `entry.js`.

Fixes: #180 

## Other Information

The test end-to-end test script and test config matrix were modified to accommodate the new SvelteKit layout system.