### PR TITLE
fix: cross-site POST requests

### DIFF
--- a/src/files/entry.js
+++ b/src/files/entry.js
@@ -4,6 +4,7 @@ import {manifest} from 'MANIFEST';
 import {toSvelteKitRequest} from './firebase-to-svelte-kit.js';
 
 const server = new Server(manifest);
+
 /**
  * Firebase Cloud Function handler for SvelteKit
  *

--- a/src/files/firebase-to-svelte-kit.js
+++ b/src/files/firebase-to-svelte-kit.js
@@ -5,7 +5,10 @@
  * @return {import('@sveltejs/kit').IncomingRequest}
  */
 export function toSvelteKitRequest(request) {
-	const host = `${request.headers['x-forwarded-proto']}://${request.headers.host}`;
+	// Firebase sometimes omits the protocol used. Default to http.
+	const protocol = request.headers['x-forwarded-proto'] || 'http';
+	// Firebase forwards the request to sveltekit, use the forwarded host.
+	const host = `${protocol}://${request.headers['x-forwarded-host']}`;
 	const {href, pathname, searchParams: searchParameters} = new URL(request.url || '', host);
 	// eslint-disable-next-line no-undef
 	return new Request(href, {

--- a/tests/end-to-end/test.bash
+++ b/tests/end-to-end/test.bash
@@ -93,10 +93,10 @@ if [[ "${RESULT}" != *"${EXPECTED_SUBSTRING}"* ]]; then
 fi
 
 echo "${INDICATOR}Test POST to '/todos' API"
-EXPECTED_SUBSTRING='"text":"asdf"'
+EXPECTED_SUBSTRING='{"type":"success","status":204}'
 # expected result = {"uid":"","created_at":01234,"text":"asdf","done":false}
 # generated from the browser & copied with 'copy for cURL' browser context menu
-RESULT="$(curl -X POST "http://localhost:${PORT}/todos" \
+RESULT="$(curl -X POST "http://localhost:${PORT}/todos?/add" \
 	-H "User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:91.0) Gecko/20100101 Firefox/91.0" \
 	-H "Accept: */*" \
 	-H "Accept-Language: en-GB,en;q=0.5" \


### PR DESCRIPTION
# Summary

Fixes the "Cross-site POST form submissions are forbidden" error, by setting the correct header origin.
Fixes: End-to-end tests.

## Other Information

<!-- If there is anything else that is relevant to your pull request include that information here. -->

<!--Thank you for contributing to svelte-adapter-firebase! -->
