### PR TITLE
fix: `firebase.json:functions` optionally as array

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ the Adapter and SvelteKit becoming incompatible. Here is a compatibility table:
 
 | Adapter Version | SvelteKit Version    |
 | --------------- | -------------------- |
+| `0.14.4`        | `1.0.0-next.443`     |
 | `0.14.3`        | `1.0.0-next.443`     |
 | `0.14.2`        | `1.0.0-next.405`     |
 | `0.14.0`        | `1.0.0-next.330`     |

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ const entrypoint = function (options = {}) {
 
 			builder.log.minor(`Adapter configuration:\n\t${JSON.stringify(options)}`);
 			const {functions, publicDir} = parseFirebaseConfiguration({firebaseJsonPath, target, sourceRewriteMatch});
-			ensureStaticResourceDirsDiffer({source: path.join(process.cwd(), builder.getStaticDirectory()), dest: publicDir});
+			ensureStaticResourceDirsDiffer({source: path.join(process.cwd(), builder.config.kit.files.assets), dest: publicDir});
 			const functionsPackageJson = JSON.parse(readFileSync(path.join(functions.source, 'package.json'), 'utf8'));
 			if (!functionsPackageJson?.main) {
 				throw new Error(`Error reading ${functionsPackageJson}. Required field "main" missing.`);

--- a/src/utils.js
+++ b/src/utils.js
@@ -159,16 +159,22 @@ function parseFirebaseConfiguration({target, sourceRewriteMatch, firebaseJsonPat
 		throw new Error('Error: Cloud Function name must use only alphanumeric characters and underscores and cannot be longer than 63 characters');
 	}
 
-	// If function, ensure function root-level field is present
-	if (!firebaseConfig?.functions || !firebaseConfig.functions?.source || !isString(firebaseConfig.functions.source)) {
-		throw new Error('Error: Required "functions.source" field is missing from Firebase Configuration file.');
+	// If function, ensure function root-level field is present. If functions is an array, gets the first entry
+	let functions;
+	if (firebaseConfig?.functions) {
+		functions = Array.isArray(firebaseConfig.functions) ? firebaseConfig.functions[0] : firebaseConfig.functions;
+		if (!functions || !isString(functions.source)) {
+			throw new Error('Error: Required "functions.source" or "functions[].source" field is missing from Firebase Configuration file.');
+		}
+	} else {
+		throw new Error('Error: Required "functions" field is missing from Firebase Configuration file.');
 	}
 
 	return {
 		functions: {
 			name: rewriteConfig.function ?? rewriteConfig.run.serviceId,
-			source: path.join(path.dirname(firebaseJson), firebaseConfig.functions.source),
-			runtime: firebaseConfig.functions?.runtime,
+			source: path.join(path.dirname(firebaseJson), functions.source),
+			runtime: functions?.runtime,
 		},
 		publicDir: path.join(path.dirname(firebaseJson), hostingConfig.public),
 	};


### PR DESCRIPTION
# Summary

`firebase init` command generates an array for `functions` field instead of an object inside the `firebase.json` file. This commit adds support to this configuration (getting the first element of the array) without removing the current implementation.

Fixes:
* #196

## Other Information

I couldn't find the documentation to this behavior but since I'm using the most recent version of the Firebase CLI, I guess this could be something the adapter should support.