### PR TITLE
fix: manage bynary data in response

### DIFF
--- a/src/files/entry.js
+++ b/src/files/entry.js
@@ -27,9 +27,9 @@ export default async function svelteKit(request, response) {
 			return request.headers.get('x-forwarded-for');
 		},
 	});
-	const body = await rendered.text();
+	const body = await rendered.arrayBuffer();
 
 	return rendered
-		? response.writeHead(rendered.status, Object.fromEntries(rendered.headers)).end(body)
+		? response.writeHead(rendered.status, Object.fromEntries(rendered.headers)).end(Buffer.from(body))
 		: response.writeHead(404, 'Not Found').end();
 }


### PR DESCRIPTION
# Summary

when trying to build a Response with binary data or stream, it fails on server side deployment with no error but blank image or pdf the conversion from Response to ServerResponse manage binary data by using ArrayBuffer and convert it in a Buffer