### PR TITLE
Add note about App Hosting in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-| :warning: WARNING: Firebase have introduced first-party support for [Web Frameworks](https://firebase.google.com/docs/hosting/frameworks/frameworks-overview). [SvelteKit support is experimental](https://github.com/FirebaseExtended/firebase-framework-tools). This adapter may be deprecated in future as it cannot support the same level of integration as the official team and tooling. Use at your own risk. |
+| :warning: WARNING: Firebase have introduced first-party support for SvelteKit on [Hosting (experimental)](https://firebase.google.com/docs/hosting/frameworks/frameworks-overview) and [App Hosting](https://firebase.blog/posts/2025/06/app-hosting-frameworks#sveltekit). This adapter may be deprecated in future as it cannot support the same level of integration as the official team and tooling. Use at your own risk. |
 | ---------------------------------------------------------------------------------------------------- |
 
 ![SvelteKit adapter Firebase social preview](assets/github-preview-svelte-adapter-firebase.png)


### PR DESCRIPTION
# Summary

I wrote a [post on the Firebase blog](https://firebase.blog/posts/2025/06/app-hosting-frameworks) about how to deploy various frameworks to App Hosting, including SvelteKit.

## Other Information

The Node.js Cloud buildpack has a [special case for SvelteKit](https://github.com/GoogleCloudPlatform/buildpacks/blob/17165a4156e95e2e9eb55ab631190d2d042e9954/pkg/nodejs/npm.go#L225) so SvelteKit will work on App Hosting and Cloud Run without additional configuration.

<!--Thank you for contributing to svelte-adapter-firebase! -->
